### PR TITLE
feat: add --mindful-mode flag to disable AI auto-confirmations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,8 @@ RUN echo '#!/bin/bash' > /opt/yolobox/wrapper-template \
     && echo 'CMD=$(basename "$0")' >> /opt/yolobox/wrapper-template \
     && echo 'CLEAN_PATH=$(echo "$PATH" | tr ":" "\n" | grep -v "^$WRAPPER_DIR$" | tr "\n" ":" | sed "s/:$//" )' >> /opt/yolobox/wrapper-template \
     && echo 'REAL_BIN=$(PATH="$CLEAN_PATH" which "$CMD" 2>/dev/null)' >> /opt/yolobox/wrapper-template \
-    && echo 'if [ -z "$REAL_BIN" ]; then echo "Error: $CMD not found" >&2; exit 1; fi' >> /opt/yolobox/wrapper-template
+    && echo 'if [ -z "$REAL_BIN" ]; then echo "Error: $CMD not found" >&2; exit 1; fi' >> /opt/yolobox/wrapper-template \
+    && echo 'if [ "$MINDFUL_MODE" = "1" ]; then exec "$REAL_BIN" "$@"; fi' >> /opt/yolobox/wrapper-template
 
 # Claude wrapper
 RUN cp /opt/yolobox/wrapper-template /opt/yolobox/bin/claude \

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ yolobox help                # Show help
 | `--env <KEY=val>` | Set environment variable (repeatable) |
 | `--ssh-agent` | Forward SSH agent socket |
 | `--no-network` | Disable network access |
+| `--mindful-mode` | Disable auto-confirmations (mindful mode) |
 | `--readonly-project` | Mount project read-only (outputs go to `/output`) |
 | `--claude-config` | Copy host `~/.claude` config into container |
 

--- a/cmd/yolobox/main.go
+++ b/cmd/yolobox/main.go
@@ -61,6 +61,7 @@ type Config struct {
 	SSHAgent        bool     `toml:"ssh_agent"`
 	ReadonlyProject bool     `toml:"readonly_project"`
 	NoNetwork       bool     `toml:"no_network"`
+	MindfulMode     bool     `toml:"mindful_mode"`
 	ClaudeConfig    bool     `toml:"claude_config"`
 }
 
@@ -264,6 +265,7 @@ func printUsage() {
 	fmt.Fprintln(os.Stderr, "  --env <KEY=val>       Set environment variable (repeatable)")
 	fmt.Fprintln(os.Stderr, "  --ssh-agent           Forward SSH agent socket")
 	fmt.Fprintln(os.Stderr, "  --no-network          Disable network access")
+	fmt.Fprintln(os.Stderr, "  --mindful-mode        Disable AI CLIs YOLO mode")
 	fmt.Fprintln(os.Stderr, "  --readonly-project    Mount project directory read-only")
 	fmt.Fprintln(os.Stderr, "  --claude-config       Copy host Claude config to container")
 	fmt.Fprintln(os.Stderr, "")
@@ -304,6 +306,7 @@ func parseBaseFlags(name string, args []string) (Config, []string, error) {
 		sshAgent        bool
 		readonlyProject bool
 		noNetwork       bool
+		mindfulMode     bool
 		claudeConfig    bool
 		mounts          stringSliceFlag
 		envVars         stringSliceFlag
@@ -314,6 +317,7 @@ func parseBaseFlags(name string, args []string) (Config, []string, error) {
 	fs.BoolVar(&sshAgent, "ssh-agent", false, "mount SSH agent socket")
 	fs.BoolVar(&readonlyProject, "readonly-project", false, "mount project read-only")
 	fs.BoolVar(&noNetwork, "no-network", false, "disable network")
+	fs.BoolVar(&mindfulMode, "mindful-mode", false, "disable AI CLIs YOLO mode")
 	fs.BoolVar(&claudeConfig, "claude-config", false, "copy host Claude config to container")
 	fs.Var(&mounts, "mount", "extra mount src:dst")
 	fs.Var(&envVars, "env", "environment variable KEY=value")
@@ -340,6 +344,9 @@ func parseBaseFlags(name string, args []string) (Config, []string, error) {
 	}
 	if noNetwork {
 		cfg.NoNetwork = true
+	}
+	if mindfulMode {
+		cfg.MindfulMode = true
 	}
 	if claudeConfig {
 		cfg.ClaudeConfig = true
@@ -525,6 +532,9 @@ func mergeConfig(dst *Config, src Config) {
 	if src.NoNetwork {
 		dst.NoNetwork = true
 	}
+	if src.MindfulMode {
+		dst.MindfulMode = true
+	}
 	if src.ClaudeConfig {
 		dst.ClaudeConfig = true
 	}
@@ -545,6 +555,9 @@ func printActiveConfig(cfg Config) {
 	}
 	if cfg.NoNetwork {
 		active = append(active, "no-network")
+	}
+	if cfg.MindfulMode {
+		active = append(active, "mindful-mode")
 	}
 	if cfg.ReadonlyProject {
 		active = append(active, "readonly-project")
@@ -591,6 +604,7 @@ func printConfig(cfg Config) error {
 	fmt.Printf("%sssh_agent:%s %t\n", colorBold, colorReset, cfg.SSHAgent)
 	fmt.Printf("%sreadonly_project:%s %t\n", colorBold, colorReset, cfg.ReadonlyProject)
 	fmt.Printf("%sno_network:%s %t\n", colorBold, colorReset, cfg.NoNetwork)
+	fmt.Printf("%smindful_mode:%s %t\n", colorBold, colorReset, cfg.MindfulMode)
 	fmt.Printf("%sclaude_config:%s %t\n", colorBold, colorReset, cfg.ClaudeConfig)
 	if len(cfg.Mounts) > 0 {
 		fmt.Printf("%smounts:%s\n", colorBold, colorReset)
@@ -727,6 +741,9 @@ func buildRunArgs(cfg Config, projectDir string, command []string, interactive b
 
 	args = append(args, "-w", "/workspace")
 	args = append(args, "-e", "YOLOBOX=1")
+	if cfg.MindfulMode {
+		args = append(args, "-e", "MINDFUL_MODE=1")
+	}
 	if term := os.Getenv("TERM"); term != "" {
 		args = append(args, "-e", "TERM="+term)
 	}

--- a/cmd/yolobox/main_test.go
+++ b/cmd/yolobox/main_test.go
@@ -173,6 +173,26 @@ func TestBuildRunArgs(t *testing.T) {
 	}
 }
 
+func TestBuildRunArgsMindfulMode(t *testing.T) {
+	cfg := Config{
+		Image:       "test-image",
+		MindfulMode: true,
+	}
+
+	args, err := buildRunArgs(cfg, "/test/project", []string{"bash"}, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	argsStr := strings.Join(args, " ")
+	if !strings.Contains(argsStr, "YOLOBOX=1") {
+		t.Error("expected YOLOBOX=1 env var to be present")
+	}
+	if !strings.Contains(argsStr, "MINDFUL_MODE=1") {
+		t.Error("expected MINDFUL_MODE=1 env var to be present")
+	}
+}
+
 func TestBuildRunArgsNoNetwork(t *testing.T) {
 	cfg := Config{
 		Image:     "test-image",


### PR DESCRIPTION
Introduces a "mindful mode" that allows users to disable the default YOLO behavior (auto-confirmations/danger flags) of AI CLIs like Claude.

This adds a new --mindful-mode CLI flag and MINDFUL_MODE environment variable, with corresponding wrapper logic in the Docker image and tests to ensure correct passthrough.