### PR TITLE
feat: add --no-yolo flag to disable AI auto-confirmations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,8 @@ RUN echo '#!/bin/bash' > /opt/yolobox/wrapper-template \
     && echo 'CMD=$(basename "$0")' >> /opt/yolobox/wrapper-template \
     && echo 'CLEAN_PATH=$(echo "$PATH" | tr ":" "\n" | grep -v "^$WRAPPER_DIR$" | tr "\n" ":" | sed "s/:$//" )' >> /opt/yolobox/wrapper-template \
     && echo 'REAL_BIN=$(PATH="$CLEAN_PATH" which "$CMD" 2>/dev/null)' >> /opt/yolobox/wrapper-template \
-    && echo 'if [ -z "$REAL_BIN" ]; then echo "Error: $CMD not found" >&2; exit 1; fi' >> /opt/yolobox/wrapper-template
+    && echo 'if [ -z "$REAL_BIN" ]; then echo "Error: $CMD not found" >&2; exit 1; fi' >> /opt/yolobox/wrapper-template \
+    && echo 'if [ "$NO_YOLO" = "1" ]; then exec "$REAL_BIN" "$@"; fi' >> /opt/yolobox/wrapper-template
 
 # Claude wrapper
 RUN cp /opt/yolobox/wrapper-template /opt/yolobox/bin/claude \

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ yolobox help                # Show help
 | `--env <KEY=val>` | Set environment variable (repeatable) |
 | `--ssh-agent` | Forward SSH agent socket |
 | `--no-network` | Disable network access |
+| `--no-yolo` | Disable auto-confirmations (mindful mode) |
 | `--readonly-project` | Mount project read-only (outputs go to `/output`) |
 | `--claude-config` | Copy host `~/.claude` config into container |
 

--- a/cmd/yolobox/main_test.go
+++ b/cmd/yolobox/main_test.go
@@ -173,6 +173,26 @@ func TestBuildRunArgs(t *testing.T) {
 	}
 }
 
+func TestBuildRunArgsNoYolo(t *testing.T) {
+	cfg := Config{
+		Image:    "test-image",
+		NoYolo: true,
+	}
+
+	args, err := buildRunArgs(cfg, "/test/project", []string{"bash"}, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	argsStr := strings.Join(args, " ")
+	if !strings.Contains(argsStr, "YOLOBOX=1") {
+		t.Error("expected YOLOBOX=1 env var to be present")
+	}
+	if !strings.Contains(argsStr, "NO_YOLO=1") {
+		t.Error("expected NO_YOLO=1 env var to be present")
+	}
+}
+
 func TestBuildRunArgsNoNetwork(t *testing.T) {
 	cfg := Config{
 		Image:     "test-image",


### PR DESCRIPTION
Introduces a "no YOLO mode" that allows users to disable the default YOLO behavior (auto-confirmations/danger flags) of AI CLIs like Claude.

This adds a new --no-yolo CLI flag and NO_YOLO environment variable, with corresponding wrapper logic in the Docker image and tests to ensure correct passthrough.

replaces #5 