### PR TITLE
feat: auto-detect TTY for interactive container sessions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,9 @@ module github.com/finbarr/yolobox
 
 go 1.22
 
-require github.com/BurntSushi/toml v1.4.0
+require (
+	github.com/BurntSushi/toml v1.4.0
+	golang.org/x/term v0.29.0
+)
+
+require golang.org/x/sys v0.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.29.0 h1:L6pJp37ocefwRRtYPKSWOWzOtWSxVajvz2ldH/xi3iU=
+golang.org/x/term v0.29.0/go.mod h1:6bl4lRlvVuDgSf3179VpIxBF0o10JUpXWOnI7nErv7s=


### PR DESCRIPTION
`yolobox run claude` did not seem to work as intended:

```
yolobox run claude
Error: Input must be provided either through stdin or as a prompt argument when using --print
```

## Summary
- Auto-detect if stdin/stdout are terminals using `golang.org/x/term`
- Enable interactive mode (`-it`) automatically when running in a terminal
- Allows `yolobox run claude` to work interactively without explicit flags