### PR TITLE
fix: run `claude install` during image build for update support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,8 +96,10 @@ COPY --from=claude-installer /root/.local/bin/claude /usr/local/bin/claude
 USER yolo
 
 # Create symlink for Claude at ~/.local/bin (host config expects it there)
+# Then run `claude install` to register installation metadata so `claude update` works
 RUN mkdir -p /home/yolo/.local/bin && \
-    ln -s /usr/local/bin/claude /home/yolo/.local/bin/claude
+    ln -s /usr/local/bin/claude /home/yolo/.local/bin/claude && \
+    claude install || true
 WORKDIR /home/yolo
 
 # Set up a fun prompt and aliases


### PR DESCRIPTION
## Summary

Fixes `claude update` failing inside the container with:
```
Warning: Running native installation but config install method is 'unknown'
Fix: Run claude install to update configuration
Failed to check for updates
```

Running `claude install` during the Docker build registers the installation metadata so updates work correctly.