### PR TITLE
feat: auto-passthrough CLAUDE_CODE_OAUTH_TOKEN to container

### DIFF
--- a/cmd/yolobox/main.go
+++ b/cmd/yolobox/main.go
@@ -49,6 +49,7 @@ const (
 // Common API keys to auto-passthrough
 var autoPassthroughEnvVars = []string{
 	"ANTHROPIC_API_KEY",
+	"CLAUDE_CODE_OAUTH_TOKEN",
 	"OPENAI_API_KEY",
 	"COPILOT_GITHUB_TOKEN",
 	"GITHUB_TOKEN",

--- a/cmd/yolobox/main_test.go
+++ b/cmd/yolobox/main_test.go
@@ -343,6 +343,7 @@ func TestAutoPassthroughEnvVars(t *testing.T) {
 	// Check that common API keys are in the list
 	expected := []string{
 		"ANTHROPIC_API_KEY",
+		"CLAUDE_CODE_OAUTH_TOKEN",
 		"OPENAI_API_KEY",
 		"COPILOT_GITHUB_TOKEN",
 		"GITHUB_TOKEN",


### PR DESCRIPTION
## Summary

- Adds `CLAUDE_CODE_OAUTH_TOKEN` to `autoPassthroughEnvVars` so it is automatically forwarded from the host environment into the container (via `-e KEY=val`) alongside the existing `ANTHROPIC_API_KEY`
- Updates `TestAutoPassthroughEnvVars` to assert the new variable is present

## Motivation

Users who authenticate with Claude via OAuth (claude.ai Pro/Teams subscriptions) set `CLAUDE_CODE_OAUTH_TOKEN` on their host rather than `ANTHROPIC_API_KEY`. Without this change they have to manually pass `--env CLAUDE_CODE_OAUTH_TOKEN=$CLAUDE_CODE_OAUTH_TOKEN` on every invocation.

CLAUDE_CODE_OAUTH_TOKEN for OAuth token authentication can be generated with `claude setup-token` on Pro and Max plans

I've tested this pattern locally.

## Test plan

- [ ] `go test ./...` passes (verified locally)
- [ ] Set `CLAUDE_CODE_OAUTH_TOKEN=<real-token>` on host, run `yolobox claude --version` — Claude authenticates without `--env` flag