### PR TITLE
fix: add ubuntu to sudoers to handle UID 1000 collision

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,8 +118,10 @@ RUN npm install -g --no-audit --no-fund \
 # =============================================================================
 
 # Create yolo user with passwordless sudo
+# Also grant same permissions to ubuntu user to handle UID collision edge cases
 RUN useradd -m -s /bin/bash yolo \
     && echo "yolo ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/yolo \
+    && echo "ubuntu ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/yolo \
     && chmod 0440 /etc/sudoers.d/yolo
 
 # Set up directories


### PR DESCRIPTION
## Problem

When running yolobox claude --claude-config (or any command with --claude-config), users with host UID 1000 are prompted for a sudo password inside the container, even though the yolo user is configured with passwordless sudo.

    The error message shows:

     1 → Copying host Claude config to container
     2 [sudo] password for ubuntu:

## Root Cause

    This is a UID collision issue:

     1. The Ubuntu base image includes a default ubuntu user with UID 1000
     2. Many Linux users have UID 1000 on their host system
     3. The yolobox entrypoint remaps the yolo user's UID to match the host project directory owner (UID 1000) to fix volume permission issues
     4. When UID 1000 is already assigned to ubuntu, the system identifies the remapped user as ubuntu instead of yolo
     5. The sudoers file (/etc/sudoers.d/yolo) only grants passwordless sudo to yolo, not ubuntu
     6. Result: sudo prompts for a password

## Why

It shows password prompt and can't be skipped

     1 → Copying host Claude config to container
     2 [sudo] password for ubuntu:

## What changed

Add the ubuntu user to the same sudoers rule to handle UID collision edge cases

## Testing

Users affected by this bug can verify the fix by:

     1. Having a host UID of 1000 (check with id -u)
     2. Running yolobox claude --claude-config
     3. Confirming no sudo password prompt appears

-->

**Environment:** Ubuntu 25.10 with docker 

## Checklist

- [x] I ran `make clean && make build && make test`
- [x] I tested the change end-to-end in a real container
