### PR TITLE
bugfiix: UID/GID of existing ubuntu login may clash with host UID/GID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,6 +117,10 @@ RUN npm install -g --no-audit --no-fund \
 # USER SETUP — small layers, stable
 # =============================================================================
 
+# Remove existing "ubuntu" user, as its UID/GID may conflict with a
+# user on the host
+RUN userdel -r ubuntu
+
 # Create yolo user with passwordless sudo
 RUN useradd -m -s /bin/bash yolo \
     && echo "yolo ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/yolo \


### PR DESCRIPTION
## Why

<!-- What problem does this solve? Why should this change exist? Link to an issue if there is one. -->

The container has an existing login (`ubuntu`) with UID/GID of 1000/1000.

On a host where the login running yolobox has that UID/GID, e.g.

```
$ id
uid=1000(dj) gid=1000(dj) 
```
`yolobox-uid-fix.sh` will change the UID/GID of yolo to 1000/1000, e.g. in `/etc/passwd:`

```
ubuntu:x:1000:1000:Ubuntu:/home/ubuntu:/bin/bash
yolo:x:1000:1000::/home/yolo:/bin/bash
```
This results in the `ubuntu` login being used instead of the `yolo` login 
```
  Welcome to yolobox!
  Your home directory is safe. Go wild.

yolo:/home/dj/Work/yolobox 🎲 whoami
ubuntu
```
presumably because it occurs first in `/etc/passwd.`  This login does not have sudo privileges, and, well, everything breaks.

## What changed

This commit removes the `ubuntu` login so that there is no possibility of a clash. Renumbering it just kicks the can down the road as it may clash with another UID/GID.  It appears to be a placeholder user account (e.g. UID is outside of the system range in `/etc/adduser.conf)` so it is safe to remove.

## Testing

<!-- How did you verify this works? Include the actual commands you ran and their output.
     Unit tests alone are not sufficient — you must test against a real container.
     Example:
       $ ./yolobox run --memory 4g echo hello
       hello
-->

```
$ make image
[...]
$ yolobox --runtime docker

  Welcome to yolobox!
  Your home directory is safe. Go wild.
[...]
yolo:/home/dj/Work/yolobox 🎲 whoami
yolo
```
**Environment:** <!-- OS, container runtime (Docker/Podman), version -->
Debian 13
Podman 5.4.2 (for the official yolobox container)
Docker version 26.1.5+dfsg1, build a72d7cd (for the fixed container)


## Checklist

- [x] I ran `make clean && make build && make test`
- [x] I tested the change end-to-end in a real container
- [ ] I updated README.md (if adding/changing flags or config)
