### PR TITLE
feat: add Java 25, Maven, and Quarkus CLI via SDKMAN

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,10 @@ make image
 ./yolobox run bun --version             # Bun
 ./yolobox run python3 --version         # Python
 ./yolobox run go version                # Go
+./yolobox run java --version            # Java 25 (SDKMAN)
+./yolobox run mvn --version             # Maven (SDKMAN)
+./yolobox run quarkus version           # Quarkus CLI (SDKMAN)
+./yolobox run sdk version               # SDKMAN
 ./yolobox run uv --version              # uv (Python package manager)
 ./yolobox run claude --version          # Claude Code
 ./yolobox run gemini --version          # Gemini CLI

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,16 @@ RUN ln -s /usr/local/bin/bun /usr/local/bin/bunx
 # Install uv (fast Python package manager)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
+# Install SDKMAN + Java 21 + Maven (system-wide so named volume doesn't shadow it)
+ENV SDKMAN_DIR=/opt/sdkman
+RUN curl -fsSL "https://get.sdkman.io" | bash \
+    && bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh && sdk install java 25-tem && sdk install maven && sdk install quarkus" \
+    && rm -rf $SDKMAN_DIR/tmp/* $SDKMAN_DIR/archives/* \
+    && printf '%s\n' '#!/bin/bash' 'source /opt/sdkman/bin/sdkman-init.sh' 'sdk "$@"' > /usr/local/bin/sdk \
+    && chmod +x /usr/local/bin/sdk
+ENV JAVA_HOME=/opt/sdkman/candidates/java/current
+ENV PATH="$SDKMAN_DIR/candidates/java/current/bin:$SDKMAN_DIR/candidates/maven/current/bin:$SDKMAN_DIR/candidates/quarkus/current/bin:$PATH"
+
 # Install Ghostty terminfo (not in Ubuntu's ncurses yet, needs 6.5+)
 # Prevents "Could not set up terminal" warnings when TERM=xterm-ghostty
 # Must be done as root to install to system terminfo directory
@@ -344,7 +354,10 @@ RUN echo 'PS1="\\[\\033[35m\\]yolo\\[\\033[0m\\]:\\[\\033[36m\\]\\w\\[\\033[0m\\
     && echo 'alias ll="ls -la"' >> ~/.bashrc \
     && echo 'alias la="ls -A"' >> ~/.bashrc \
     && echo 'alias l="ls -CF"' >> ~/.bashrc \
-    && echo 'alias yeet="rm -rf"' >> ~/.bashrc
+    && echo 'alias yeet="rm -rf"' >> ~/.bashrc \
+    && echo '# SDKMAN' >> ~/.bashrc \
+    && echo 'export SDKMAN_DIR=/opt/sdkman' >> ~/.bashrc \
+    && echo '[[ -s "$SDKMAN_DIR/bin/sdkman-init.sh" ]] && source "$SDKMAN_DIR/bin/sdkman-init.sh"' >> ~/.bashrc
 
 # Welcome message
 RUN echo 'echo ""' >> ~/.bashrc \

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ image:
 		docker buildx build -t $(IMAGE) . || \
 		docker build -t $(IMAGE) .
 
-SMOKE_TOOLS := node bun python3 uv gh fish fd bat rg eza
+SMOKE_TOOLS := node bun python3 uv gh fish fd bat rg eza java mvn
 
 smoke-test: build
 	@echo "Running smoke tests..."
@@ -40,6 +40,18 @@ smoke-test: build
 		echo "  ✓ go"; \
 	else \
 		echo "  ✗ go"; \
+		failed=1; \
+	fi; \
+	if ./$(BINARY) run --scratch sdk version >/dev/null 2>&1; then \
+		echo "  ✓ sdk"; \
+	else \
+		echo "  ✗ sdk"; \
+		failed=1; \
+	fi; \
+	if ./$(BINARY) run --scratch quarkus version >/dev/null 2>&1; then \
+		echo "  ✓ quarkus"; \
+	else \
+		echo "  ✗ quarkus"; \
 		failed=1; \
 	fi; \
 	if ./$(BINARY) run --scratch claude --version >/dev/null 2>&1; then \

--- a/README.md
+++ b/README.md
@@ -189,12 +189,29 @@ These are automatically passed into the container if set:
 
 The base image comes batteries-included:
 - **AI CLIs**: Claude Code, Gemini CLI, OpenAI Codex, OpenCode, Copilot (all pre-configured for full-auto mode!)
-- **Runtimes**: Node.js 22, Python 3, Go, Bun
+- **Runtimes**: Node.js 22, Python 3, Go, Bun, Java 25 (SDKMAN)
+- **Java tools**: Maven, Quarkus CLI (via SDKMAN)
 - **Build tools**: make, cmake, gcc
 - **Git** + **GitHub CLI**
 - **Common utilities**: ripgrep, fd, fzf, jq, vim
 
 Need something else? The AI has sudo.
+
+### Java / SDKMAN
+
+Java 25 (Eclipse Temurin), Maven, and Quarkus CLI are pre-installed via [SDKMAN](https://sdkman.io/). SDKMAN is installed system-wide at `/opt/sdkman`.
+
+```bash
+# Check installed versions
+yolobox run java --version
+yolobox run mvn --version
+yolobox run quarkus version
+
+# Use sdk to manage Java versions at runtime
+yolobox run sdk list java
+yolobox run sdk install java 21-tem
+yolobox run sdk use java 21-tem
+```
 
 ### AI CLIs Run in YOLO Mode
 


### PR DESCRIPTION
Install SDKMAN system-wide at /opt/sdkman to avoid named volume
shadowing. Includes Eclipse Temurin Java 25, Maven, and Quarkus
CLI. SDKMAN is sourced in .bashrc for interactive sdk usage.

I hope you will accept this PR, but I can understand if you don't want
to for whatever reason. Thank you for developing yolobox in any case!

## Why

Java is one of the most widely used languages for backend
development, but yolobox doesn't ship with a JDK. This makes it
harder to use AI coding agents on Java projects out of the box.
SDKMAN also makes it easy for users to switch Java versions or
install additional JVM tools at runtime.

## What changed

- Dockerfile: Install SDKMAN to /opt/sdkman (system-wide, avoids
named volume shadowing), with Java 25 (Eclipse Temurin), Maven, and
Quarkus CLI. Added a /usr/local/bin/sdk wrapper so sdk works as a
command (not just a shell function). SDKMAN sourced in .bashrc for
interactive use.
- Makefile: Added java, mvn, sdk, and quarkus to smoke tests.
- README.md: Updated "What's in the Box?" runtimes list.
- CLAUDE.md: Added java, mvn, and quarkus to verification
checklist.

## Testing

```bash
$ make clean && make build && make test
# All 44 tests pass

$ ./yolobox run java --version
openjdk 25 2025-09-16 LTS
OpenJDK Runtime Environment Temurin-25+36 (build 25+36-LTS)
OpenJDK 64-Bit Server VM Temurin-25+36 (build 25+36-LTS, mixed
mode, sharing)

$ ./yolobox run mvn --version
Apache Maven 3.9.14 (996c630dbc656c76214ce58821dcc58be960875b)
Maven home: /opt/sdkman/candidates/maven/current
Java version: 25, vendor: Eclipse Adoptium, runtime:
/opt/sdkman/candidates/java/25-tem

$ ./yolobox run quarkus version
3.32.3

$ ./yolobox run sdk version
SDKMAN!
script: 5.20.0
native: 0.7.21 (linux aarch64)

$ ./yolobox run sdk list java | head -5
# Lists available Java versions successfully

$ make smoke-test
# java ✓, mvn ✓, sdk ✓, quarkus ✓ (all pass)
```

Environment: macOS (Darwin 24.6.0), OrbStack/Docker, aarch64

Checklist

- [x] I ran make clean && make build && make test
- [x] I tested the change end-to-end in a real container
- [x] I updated README.md (if adding/changing flags or config)
