### PR TITLE
feat: add build-time container customization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,9 @@ Do NOT:
 - Push a fix for a bug without reproducing the original failure first and confirming it's gone
 
 **When adding new flags or config options:**
-1. Add the flag to `cmd/yolobox/main.go` (Config struct, parseBaseFlags, mergeConfig, buildRunArgs, printConfig, saveGlobalConfig, runSetup)
+1. Add the flag/config handling to `cmd/yolobox/main.go`:
+   - Always consider `Config`, `parseBaseFlags`, `mergeConfig`, `printConfig`, and any runtime path that consumes the option
+   - Update `saveGlobalConfig` and `runSetup` if the option should be persisted/configured globally
 2. Update `README.md`:
    - Add to the Flags table
    - Add to the example config.toml if it's a persistent option
@@ -99,26 +101,38 @@ make image
 ./yolobox run --env FOO=bar bash -c 'echo $FOO'           # Should output: bar
 ./yolobox run --no-network curl https://google.com        # Should fail
 ./yolobox run --readonly-project touch testfile           # Should fail (project is read-only)
+./yolobox run --packages cowsay cowsay hello              # Should build custom image and run cowsay
 
-# 8. API key passthrough
+# 8. Project-level customization
+YB="$(pwd)/yolobox"
+mkdir -p /tmp/yolobox-customize-test && cd /tmp/yolobox-customize-test
+printf '[customize]\npackages = ["cowsay"]\n' > .yolobox.toml
+$YB run cowsay hello                                      # First run builds derived image
+$YB run cowsay cached                                     # Second run should reuse it
+printf 'USER root\nRUN apt-get update && apt-get install -y cowsay\nUSER yolo\n' > .yolobox.Dockerfile
+printf '[customize]\ndockerfile = ".yolobox.Dockerfile"\n' > .yolobox.toml
+$YB run /usr/games/cowsay hello                           # Fragment-based customization
+cd - && rm -rf /tmp/yolobox-customize-test
+
+# 9. API key passthrough
 ANTHROPIC_API_KEY=test ./yolobox run printenv ANTHROPIC_API_KEY  # Should output: test
 
-# 9. Claude config sharing (opt-in with --claude-config)
+# 10. Claude config sharing (opt-in with --claude-config)
 ./yolobox run --claude-config ls /home/yolo/.claude   # Should show copied host claude config
 
-# 10. Gemini config sharing (opt-in with --gemini-config)
+# 11. Gemini config sharing (opt-in with --gemini-config)
 ./yolobox run --gemini-config ls /home/yolo/.gemini   # Should show copied host gemini config
 
-# 11. Git config sharing (opt-in with --git-config)
+# 12. Git config sharing (opt-in with --git-config)
 ./yolobox run --git-config cat /home/yolo/.gitconfig  # Should show copied host git config
 
-# 12. Docker socket forwarding (opt-in with --docker)
+# 13. Docker socket forwarding (opt-in with --docker)
 ./yolobox run --docker docker version                         # Should show Docker version
 ./yolobox run --docker docker compose version                 # Should show Compose version
 ./yolobox run --docker bash -c 'echo $YOLOBOX_NETWORK'       # Should output: yolobox-net
 ./yolobox run --docker --no-network echo hi                   # Should error (conflict)
 
-# 13. Global agent instructions (opt-in with --copy-agent-instructions)
+# 14. Global agent instructions (opt-in with --copy-agent-instructions)
 # Creates test file, copies it, then cleans up
 mkdir -p ~/.claude && echo "test" > ~/.claude/CLAUDE.md
 ./yolobox run --copy-agent-instructions cat /home/yolo/.claude/CLAUDE.md  # Should output: test
@@ -131,20 +145,22 @@ yolobox is a single-binary Go CLI that runs AI coding agents (Claude Code, Codex
 
 ### Code Structure
 
-All code lives in `cmd/yolobox/main.go` (~700 lines):
+All code lives in `cmd/yolobox/main.go` (~2600 lines):
 
-- **Config struct** - TOML config with runtime, image, mounts, secrets, env, resource limits, network/readonly flags
+- **Config struct** - TOML config with runtime, image, mounts, env, customization, resource limits, and sharing flags
 - **loadConfig()** - Merges global (`~/.config/yolobox/config.toml`) + project (`.yolobox.toml`) + CLI flags
 - **buildRunArgs()** - Constructs docker/podman run arguments
+- **prepareCustomImage()** - Builds or reuses derived images for project-level customization
 - **resolveRuntime()** - Auto-detects docker or podman
 - **Color helpers** - `success()`, `info()`, `warn()`, `errorf()` for colorful output
 
 ### Key Design Decisions
 
 - Single file keeps it auditable and simple
-- Named volumes (`yolobox-home`, `yolobox-cache`, `yolobox-tools`) persist across runs
+- Named volumes (`yolobox-home`, `yolobox-cache`, and `yolobox-output` when needed) persist across runs
 - Auto-passthrough of common API keys (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.)
 - Container user is `yolo` with passwordless sudo
+- Project-level customization builds derived images from `customize.packages` and/or `customize.dockerfile`
 - Flags are parsed per-subcommand (e.g., `yolobox run --env FOO=bar cmd`, not `yolobox --env FOO=bar run cmd`)
 
 ### Container Behavior

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ yolobox help                # Show help
 | `--cap-add <cap>` | Add Linux capabilities (repeatable) |
 | `--cap-drop <cap>` | Drop Linux capabilities (repeatable) |
 | `--runtime-arg <flag>` | Pass raw runtime flags directly to Docker/Podman (repeatable) |
+| `--packages <list>` | Comma-separated apt packages for a derived custom image |
+| `--customize-file <path>` | Dockerfile fragment for a derived custom image |
+| `--rebuild-image` | Force rebuild of the derived custom image |
 
 > **Resource & security controls:** The table lists the common knobs baked into yolobox. Anything else (e.g., `--ulimit nofile=4096:8192`, `--security-opt seccomp=unconfined`) can be forwarded verbatim with `--runtime-arg <flag>` as many times as needed. Docker and Podman accept the passthrough flags unchanged; Apple's `container` runtime ignores options it doesn't understand.
 
@@ -156,6 +159,61 @@ Priority: CLI flags > project config > global config > defaults.
 Each `runtime_args` entry is a single CLI argument. For flags that take a value, add them as separate entries so `--security-opt seccomp=unconfined` becomes `["--security-opt", "seccomp=unconfined"]`.
 
 > **Note:** Setting `claude_config = true` or `gemini_config = true` in your config will copy your host config on **every** container start, overwriting any changes made inside the container (including auth and history). Prefer using `--claude-config` or `--gemini-config` for one-time syncs.
+
+### Project-Level Container Customization
+
+Need extra tools for one project without bloating the base image? yolobox can build and cache a derived image from your project config.
+
+Simple case:
+
+```toml
+# .yolobox.toml
+[customize]
+packages = ["default-jdk", "maven"]
+```
+
+Then run normally:
+
+```bash
+yolobox run mvn --version
+```
+
+For more advanced setups, add a Dockerfile fragment:
+
+```toml
+# .yolobox.toml
+[customize]
+dockerfile = ".yolobox.Dockerfile"
+```
+
+```dockerfile
+# .yolobox.Dockerfile
+USER root
+RUN curl -fsSL https://get.sdkman.io | bash
+USER yolo
+```
+
+You can combine both. `packages` install first, then the fragment runs on top.
+
+For one-offs, use flags:
+
+```bash
+yolobox run --packages default-jdk,maven mvn --version
+yolobox run --customize-file .yolobox.Dockerfile bash
+yolobox run --packages default-jdk --rebuild-image java --version
+```
+
+The first run builds a derived image. Later runs reuse it until the base image or customization inputs change. When you use a Dockerfile fragment, yolobox asks Docker/Podman to build again so context changes are noticed, but cached layers are reused when nothing changed.
+
+This also keeps `yolobox upgrade` relatively painless:
+
+- `yolobox upgrade` still updates the binary and pulls the latest base image
+- your project-level customization stays in `.yolobox.toml` / `.yolobox.Dockerfile`
+- the next run rebuilds the derived image only if the new base image or your customization inputs changed
+
+You still pay one rebuild after a base-image upgrade, but you do not need to manually rebase a forked Dockerfile just to keep using the feature.
+
+> **Note:** Derived-image customization requires a runtime that can build images (`docker` or `podman`). Apple's `container` runtime can run yolobox, but it cannot build custom images.
 
 ### Copying Global Agent Instructions
 
@@ -311,7 +369,7 @@ This builds `ghcr.io/finbarr/yolobox:latest` locally, overriding the remote imag
 
 ## Customizing the Image
 
-Want to pre-install additional packages or tools? Create your own image:
+Need more control than `packages` or a small Dockerfile fragment? You can still build and use a fully custom image:
 
 **1. Clone and modify:**
 ```bash
@@ -331,7 +389,16 @@ mkdir -p ~/.config/yolobox
 echo 'image = "my-yolobox:latest"' > ~/.config/yolobox/config.toml
 ```
 
-Using a custom image name means `yolobox upgrade` won't overwrite your customization. When you update your Dockerfile, just rebuild with the same command.
+Using a custom image name means `yolobox upgrade` won't overwrite your customization. That is the upside.
+
+The downside is that you now own the drift:
+
+- upstream Dockerfile changes do not automatically flow into your custom image
+- `yolobox upgrade` will update the binary, but it will not rebuild or migrate your custom image for you
+- when the base image changes upstream, you need to pull those changes into your fork and rebuild manually
+- the farther your custom Dockerfile drifts, the more upgrade work you take on
+
+If you mostly need "add a few tools for this project", prefer project-level customization above. Use a fully custom image only when you need full control over the entire base image.
 
 ## Development
 

--- a/cmd/yolobox/main.go
+++ b/cmd/yolobox/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -13,6 +15,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -71,6 +74,12 @@ var toolShortcuts = []string{
 }
 
 var sizePattern = regexp.MustCompile(`^\d+(?:\.\d+)?(?:[kKmMgGtTpP](?:i?[bB]?)?|[bB])?$`)
+var packageNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9.+\-:]*$`)
+
+type CustomizeConfig struct {
+	Packages   []string `toml:"packages"`
+	Dockerfile string   `toml:"dockerfile"`
+}
 
 type Config struct {
 	Runtime               string   `toml:"runtime"`
@@ -92,17 +101,19 @@ type Config struct {
 	Docker                bool     `toml:"docker"`
 
 	// Resource limits
-	CPUs        string   `toml:"cpus"`
-	Memory      string   `toml:"memory"`
-	ShmSize     string   `toml:"shm_size"`
-	GPUs        string   `toml:"gpus"`
-	Devices     []string `toml:"devices"`
-	CapAdd      []string `toml:"cap_add"`
-	CapDrop     []string `toml:"cap_drop"`
-	RuntimeArgs []string `toml:"runtime_args"`
+	CPUs        string          `toml:"cpus"`
+	Memory      string          `toml:"memory"`
+	ShmSize     string          `toml:"shm_size"`
+	GPUs        string          `toml:"gpus"`
+	Devices     []string        `toml:"devices"`
+	CapAdd      []string        `toml:"cap_add"`
+	CapDrop     []string        `toml:"cap_drop"`
+	RuntimeArgs []string        `toml:"runtime_args"`
+	Customize   CustomizeConfig `toml:"customize"`
 
 	// Runtime-only fields (not persisted to config file)
-	Setup bool `toml:"-"` // Run interactive setup before starting
+	Setup        bool `toml:"-"` // Run interactive setup before starting
+	RebuildImage bool `toml:"-"`
 }
 
 type stringSliceFlag []string
@@ -362,6 +373,9 @@ func printUsage() {
 	fmt.Fprintln(os.Stderr, "  --cap-add <name>      Add a Linux capability (repeatable)")
 	fmt.Fprintln(os.Stderr, "  --cap-drop <name>     Drop a Linux capability (repeatable)")
 	fmt.Fprintln(os.Stderr, "  --runtime-arg <flag>  Raw runtime flag passthrough (repeatable)")
+	fmt.Fprintln(os.Stderr, "  --packages <list>     Comma-separated apt packages for a custom image")
+	fmt.Fprintln(os.Stderr, "  --customize-file <path> Dockerfile fragment for a custom image")
+	fmt.Fprintln(os.Stderr, "  --rebuild-image       Force rebuild of the custom image")
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintf(os.Stderr, "%sCONFIG:%s\n", colorBold, colorReset)
 	fmt.Fprintln(os.Stderr, "  Global:  ~/.config/yolobox/config.toml")
@@ -414,14 +428,17 @@ func parseBaseFlags(name string, args []string, projectDir string) (Config, []st
 		envVars               stringSliceFlag
 
 		// Resource limits & security
-		cpus        string
-		memoryLimit string
-		shmSize     string
-		gpus        string
-		devices     stringSliceFlag
-		capAdd      stringSliceFlag
-		capDrop     stringSliceFlag
-		runtimeArgs stringSliceFlag
+		cpus          string
+		memoryLimit   string
+		shmSize       string
+		gpus          string
+		devices       stringSliceFlag
+		capAdd        stringSliceFlag
+		capDrop       stringSliceFlag
+		runtimeArgs   stringSliceFlag
+		packages      string
+		customizeFile string
+		rebuildImage  bool
 	)
 
 	fs.StringVar(&runtimeFlag, "runtime", "", "container runtime")
@@ -452,6 +469,9 @@ func parseBaseFlags(name string, args []string, projectDir string) (Config, []st
 	fs.Var(&capAdd, "cap-add", "add Linux capability (repeatable)")
 	fs.Var(&capDrop, "cap-drop", "drop Linux capability (repeatable)")
 	fs.Var(&runtimeArgs, "runtime-arg", "raw runtime flag to pass through to the container engine (repeatable)")
+	fs.StringVar(&packages, "packages", "", "comma-separated apt packages for a custom image")
+	fs.StringVar(&customizeFile, "customize-file", "", "path to a Dockerfile fragment for a custom image")
+	fs.BoolVar(&rebuildImage, "rebuild-image", false, "force rebuild of the custom image")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -541,12 +561,24 @@ func parseBaseFlags(name string, args []string, projectDir string) (Config, []st
 	if len(runtimeArgs) > 0 {
 		cfg.RuntimeArgs = append(cfg.RuntimeArgs, runtimeArgs...)
 	}
+	if packages != "" {
+		cfg.Customize.Packages = append(cfg.Customize.Packages, parseCommaSeparatedValues(packages)...)
+	}
+	if customizeFile != "" {
+		cfg.Customize.Dockerfile = customizeFile
+	}
+	if rebuildImage {
+		cfg.RebuildImage = true
+	}
 
 	// Validate conflicting options after config + CLI values have been merged.
 	if err := validateConfigConflicts(cfg); err != nil {
 		return cfg, nil, err
 	}
 	if err := validateRuntimeOptions(cfg); err != nil {
+		return cfg, nil, err
+	}
+	if err := validateCustomizeConfig(cfg.Customize); err != nil {
 		return cfg, nil, err
 	}
 
@@ -777,6 +809,12 @@ func mergeConfig(dst *Config, src Config) {
 	if len(src.RuntimeArgs) > 0 {
 		dst.RuntimeArgs = append([]string{}, src.RuntimeArgs...)
 	}
+	if len(src.Customize.Packages) > 0 {
+		dst.Customize.Packages = append([]string{}, src.Customize.Packages...)
+	}
+	if src.Customize.Dockerfile != "" {
+		dst.Customize.Dockerfile = src.Customize.Dockerfile
+	}
 }
 
 func runShell(cfg Config) error {
@@ -825,6 +863,13 @@ func runCommand(cfg Config, command []string, interactive bool) error {
 
 	if err := validateRuntimeConstraints(cfg); err != nil {
 		return err
+	}
+	if hasCustomization(cfg) {
+		customImage, err := prepareCustomImage(&cfg, projectDir)
+		if err != nil {
+			return err
+		}
+		cfg.Image = customImage
 	}
 	warnSecurityRelaxations(cfg)
 
@@ -885,6 +930,8 @@ func printConfig(cfg Config) error {
 	printSliceConfigField("cap_add", cfg.CapAdd)
 	printSliceConfigField("cap_drop", cfg.CapDrop)
 	printSliceConfigField("runtime_args", cfg.RuntimeArgs)
+	printSliceConfigField("customize.packages", cfg.Customize.Packages)
+	printStringConfigField("customize.dockerfile", cfg.Customize.Dockerfile)
 
 	if len(cfg.Mounts) > 0 {
 		fmt.Printf("%smounts:%s\n", colorBold, colorReset)
@@ -995,6 +1042,15 @@ func saveGlobalConfig(cfg Config) error {
 	}
 	if len(cfg.RuntimeArgs) > 0 {
 		lines = append(lines, fmt.Sprintf("runtime_args = %s", formatTomlStringSlice(cfg.RuntimeArgs)))
+	}
+	if len(cfg.Customize.Packages) > 0 || cfg.Customize.Dockerfile != "" {
+		lines = append(lines, "", "[customize]")
+		if len(cfg.Customize.Packages) > 0 {
+			lines = append(lines, fmt.Sprintf("packages = %s", formatTomlStringSlice(cfg.Customize.Packages)))
+		}
+		if cfg.Customize.Dockerfile != "" {
+			lines = append(lines, fmt.Sprintf("dockerfile = %q", cfg.Customize.Dockerfile))
+		}
 	}
 
 	content := strings.Join(lines, "\n")
@@ -1266,13 +1322,14 @@ func splitToolArgs(args []string) (yoloboxArgs, toolArgs []string) {
 		"env": true, "h": true, "help": true,
 		"cpus": true, "memory": true, "shm-size": true, "gpus": true,
 		"device": true, "cap-add": true, "cap-drop": true, "runtime-arg": true,
+		"packages": true, "customize-file": true, "rebuild-image": true,
 	}
 
 	flagsWithValues := map[string]bool{
 		"runtime": true, "image": true, "network": true, "pod": true,
 		"mount": true, "env": true, "cpus": true, "memory": true,
 		"shm-size": true, "device": true, "cap-add": true, "cap-drop": true,
-		"gpus": true, "runtime-arg": true,
+		"gpus": true, "runtime-arg": true, "packages": true, "customize-file": true,
 	}
 
 	i := 0
@@ -2070,6 +2127,207 @@ func resolvedRuntimeName(name string) string {
 		return "docker"
 	}
 	return name
+}
+
+func parseCommaSeparatedValues(input string) []string {
+	parts := strings.Split(input, ",")
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		values = append(values, part)
+	}
+	return values
+}
+
+func hasCustomization(cfg Config) bool {
+	return len(cfg.Customize.Packages) > 0 || strings.TrimSpace(cfg.Customize.Dockerfile) != ""
+}
+
+func validateCustomizeConfig(cfg CustomizeConfig) error {
+	for _, pkg := range cfg.Packages {
+		if !isValidPackageName(pkg) {
+			return fmt.Errorf("invalid package name %q", pkg)
+		}
+	}
+	return nil
+}
+
+func isValidPackageName(name string) bool {
+	return packageNamePattern.MatchString(strings.TrimSpace(name))
+}
+
+func normalizePackages(packages []string) []string {
+	seen := make(map[string]struct{}, len(packages))
+	normalized := make([]string, 0, len(packages))
+	for _, pkg := range packages {
+		pkg = strings.TrimSpace(pkg)
+		if pkg == "" {
+			continue
+		}
+		if _, ok := seen[pkg]; ok {
+			continue
+		}
+		seen[pkg] = struct{}{}
+		normalized = append(normalized, pkg)
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func resolveCustomizeFile(path, projectDir string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", nil
+	}
+	return resolvePath(path, projectDir)
+}
+
+func loadCustomizeFragment(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read customize file %q: %w", path, err)
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func generateCustomDockerfile(baseImage string, packages []string, fragment string) (string, error) {
+	normalized := normalizePackages(packages)
+	for _, pkg := range normalized {
+		if !isValidPackageName(pkg) {
+			return "", fmt.Errorf("invalid package name %q", pkg)
+		}
+	}
+
+	var builder strings.Builder
+	builder.WriteString("# syntax=docker/dockerfile:1\n")
+	builder.WriteString("FROM ")
+	builder.WriteString(baseImage)
+	builder.WriteString("\n")
+
+	if len(normalized) > 0 {
+		builder.WriteString("USER root\n")
+		builder.WriteString("RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \\\n")
+		builder.WriteString("    --mount=type=cache,target=/var/lib/apt,sharing=locked \\\n")
+		builder.WriteString("    apt-get update && apt-get install -y --no-install-recommends ")
+		builder.WriteString(strings.Join(normalized, " "))
+		builder.WriteString(" && rm -rf /var/lib/apt/lists/*\n")
+		builder.WriteString("USER yolo\n")
+	}
+
+	if fragment != "" {
+		builder.WriteString("\n")
+		builder.WriteString(fragment)
+		if !strings.HasSuffix(fragment, "\n") {
+			builder.WriteString("\n")
+		}
+	}
+
+	return builder.String(), nil
+}
+
+func customImageTag(baseImageID, dockerfile string, packages []string) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		baseImageID,
+		strings.Join(normalizePackages(packages), "\n"),
+		dockerfile,
+	}, "\n---\n")))
+	return "yolobox-custom:" + hex.EncodeToString(sum[:])[:12]
+}
+
+func inspectImageID(runtimePath, image string) (string, error) {
+	cmd := exec.Command(runtimePath, "image", "inspect", image, "--format", "{{.Id}}")
+	output, err := cmd.Output()
+	if err != nil {
+		pullCmd := exec.Command(runtimePath, "pull", image)
+		pullCmd.Stdin = os.Stdin
+		pullCmd.Stdout = os.Stdout
+		pullCmd.Stderr = os.Stderr
+		if pullErr := pullCmd.Run(); pullErr != nil {
+			return "", fmt.Errorf("failed to inspect or pull base image %q: %w", image, err)
+		}
+
+		cmd = exec.Command(runtimePath, "image", "inspect", image, "--format", "{{.Id}}")
+		output, err = cmd.Output()
+		if err != nil {
+			return "", fmt.Errorf("failed to inspect base image %q: %w", image, err)
+		}
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func customImageExists(runtimePath, tag string) bool {
+	return exec.Command(runtimePath, "image", "inspect", tag).Run() == nil
+}
+
+func buildCustomImage(runtimePath, tag, dockerfilePath, contextDir string) error {
+	cmd := exec.Command(runtimePath, "build", "-t", tag, "-f", dockerfilePath, contextDir)
+	cmd.Env = append(os.Environ(), "DOCKER_BUILDKIT=1")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func prepareCustomImage(cfg *Config, projectDir string) (string, error) {
+	runtimePath, err := resolveRuntime(cfg.Runtime)
+	if err != nil {
+		return "", err
+	}
+	if filepath.Base(runtimePath) == "container" {
+		return "", fmt.Errorf("custom images are not supported with Apple container runtime")
+	}
+
+	customizeFile, err := resolveCustomizeFile(cfg.Customize.Dockerfile, projectDir)
+	if err != nil {
+		return "", err
+	}
+	cfg.Customize.Dockerfile = customizeFile
+
+	fragment, err := loadCustomizeFragment(customizeFile)
+	if err != nil {
+		return "", err
+	}
+	dockerfile, err := generateCustomDockerfile(cfg.Image, cfg.Customize.Packages, fragment)
+	if err != nil {
+		return "", err
+	}
+	baseImageID, err := inspectImageID(runtimePath, cfg.Image)
+	if err != nil {
+		return "", err
+	}
+	tag := customImageTag(baseImageID, dockerfile, cfg.Customize.Packages)
+
+	if !cfg.RebuildImage && customizeFile == "" && customImageExists(runtimePath, tag) {
+		info("Using custom image %s", tag)
+		return tag, nil
+	}
+
+	buildDir, err := os.MkdirTemp("", "yolobox-custom-image-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp build dir: %w", err)
+	}
+	defer os.RemoveAll(buildDir)
+
+	dockerfilePath := filepath.Join(buildDir, "Dockerfile")
+	if err := os.WriteFile(dockerfilePath, []byte(dockerfile), 0644); err != nil {
+		return "", fmt.Errorf("failed to write generated Dockerfile: %w", err)
+	}
+
+	contextDir := buildDir
+	if customizeFile != "" {
+		contextDir = projectDir
+	}
+
+	info("Building custom image %s...", tag)
+	if err := buildCustomImage(runtimePath, tag, dockerfilePath, contextDir); err != nil {
+		return "", fmt.Errorf("failed to build custom image: %w", err)
+	}
+	return tag, nil
 }
 
 func resolveRuntime(name string) (string, error) {

--- a/cmd/yolobox/main_test.go
+++ b/cmd/yolobox/main_test.go
@@ -49,6 +49,25 @@ func TestMergeConfig(t *testing.T) {
 	}
 }
 
+func TestMergeConfigCustomize(t *testing.T) {
+	dst := Config{}
+	src := Config{
+		Customize: CustomizeConfig{
+			Packages:   []string{"maven", "default-jdk"},
+			Dockerfile: ".yolobox.Dockerfile",
+		},
+	}
+
+	mergeConfig(&dst, src)
+
+	if len(dst.Customize.Packages) != 2 {
+		t.Fatalf("expected 2 customize packages, got %v", dst.Customize.Packages)
+	}
+	if dst.Customize.Dockerfile != ".yolobox.Dockerfile" {
+		t.Fatalf("expected customize dockerfile to merge, got %q", dst.Customize.Dockerfile)
+	}
+}
+
 func TestResolvePath(t *testing.T) {
 	home, _ := os.UserHomeDir()
 	projectDir := "/project"
@@ -391,6 +410,110 @@ func TestParseFlagsScratch(t *testing.T) {
 	}
 	if len(rest) != 2 || rest[0] != "echo" || rest[1] != "hello" {
 		t.Errorf("expected remaining args [echo hello], got %v", rest)
+	}
+}
+
+func TestParseFlagsCustomize(t *testing.T) {
+	projectDir := t.TempDir()
+	cfg, rest, err := parseBaseFlags("run", []string{
+		"--packages", "default-jdk, maven",
+		"--customize-file", ".yolobox.Dockerfile",
+		"--rebuild-image",
+		"java", "--version",
+	}, projectDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(cfg.Customize.Packages) != 2 || cfg.Customize.Packages[0] != "default-jdk" || cfg.Customize.Packages[1] != "maven" {
+		t.Fatalf("unexpected customize packages: %v", cfg.Customize.Packages)
+	}
+	if cfg.Customize.Dockerfile != ".yolobox.Dockerfile" {
+		t.Fatalf("unexpected customize dockerfile: %q", cfg.Customize.Dockerfile)
+	}
+	if !cfg.RebuildImage {
+		t.Fatal("expected RebuildImage to be true")
+	}
+	if len(rest) != 2 || rest[0] != "java" || rest[1] != "--version" {
+		t.Fatalf("unexpected remaining args: %v", rest)
+	}
+}
+
+func TestParseFlagsCustomizeInvalidPackage(t *testing.T) {
+	_, _, err := parseBaseFlags("run", []string{"--packages", "default-jdk,$(evil)", "java"}, t.TempDir())
+	if err == nil {
+		t.Fatal("expected invalid package name error")
+	}
+}
+
+func TestHasCustomization(t *testing.T) {
+	if hasCustomization(Config{}) {
+		t.Fatal("expected empty config to have no customization")
+	}
+	if !hasCustomization(Config{Customize: CustomizeConfig{Packages: []string{"default-jdk"}}}) {
+		t.Fatal("expected packages customization to be detected")
+	}
+	if !hasCustomization(Config{Customize: CustomizeConfig{Dockerfile: ".yolobox.Dockerfile"}}) {
+		t.Fatal("expected dockerfile customization to be detected")
+	}
+}
+
+func TestGenerateCustomDockerfile(t *testing.T) {
+	dockerfile, err := generateCustomDockerfile("ghcr.io/finbarr/yolobox:latest", []string{"maven", "default-jdk", "maven"}, "USER root\nRUN echo hi\nUSER yolo\n")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(dockerfile, "FROM ghcr.io/finbarr/yolobox:latest") {
+		t.Fatalf("expected base image in generated Dockerfile:\n%s", dockerfile)
+	}
+	if !strings.Contains(dockerfile, "apt-get install -y --no-install-recommends default-jdk maven") {
+		t.Fatalf("expected sorted package install in generated Dockerfile:\n%s", dockerfile)
+	}
+	if !strings.Contains(dockerfile, "RUN echo hi") {
+		t.Fatalf("expected fragment content in generated Dockerfile:\n%s", dockerfile)
+	}
+}
+
+func TestGenerateCustomDockerfileRejectsInvalidPackage(t *testing.T) {
+	_, err := generateCustomDockerfile("base", []string{"$(evil)"}, "")
+	if err == nil {
+		t.Fatal("expected invalid package to be rejected")
+	}
+}
+
+func TestCustomImageTagStable(t *testing.T) {
+	tagA := customImageTag("sha256:base", "FROM base\n", []string{"maven", "default-jdk"})
+	tagB := customImageTag("sha256:base", "FROM base\n", []string{"default-jdk", "maven", "maven"})
+	if tagA != tagB {
+		t.Fatalf("expected normalized package order to yield same tag, got %q vs %q", tagA, tagB)
+	}
+}
+
+func TestResolveCustomizeFile(t *testing.T) {
+	projectDir := t.TempDir()
+	got, err := resolveCustomizeFile(".yolobox.Dockerfile", projectDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != filepath.Join(projectDir, ".yolobox.Dockerfile") {
+		t.Fatalf("unexpected resolved customize file: %q", got)
+	}
+}
+
+func TestLoadCustomizeFragment(t *testing.T) {
+	projectDir := t.TempDir()
+	path := filepath.Join(projectDir, ".yolobox.Dockerfile")
+	if err := os.WriteFile(path, []byte("USER root\nRUN echo hi\n"), 0644); err != nil {
+		t.Fatalf("failed to write test customize file: %v", err)
+	}
+
+	got, err := loadCustomizeFragment(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "USER root\nRUN echo hi" {
+		t.Fatalf("unexpected customize fragment contents: %q", got)
 	}
 }
 
@@ -770,6 +893,12 @@ func TestSplitToolArgs(t *testing.T) {
 			args:        []string{"--no-network", "--scratch", "--resume", "abc123"},
 			wantYolobox: []string{"--no-network", "--scratch"},
 			wantTool:    []string{"--resume", "abc123"},
+		},
+		{
+			name:        "customization flags stay with yolobox",
+			args:        []string{"--packages", "default-jdk,maven", "--rebuild-image", "--resume"},
+			wantYolobox: []string{"--packages", "default-jdk,maven", "--rebuild-image"},
+			wantTool:    []string{"--resume"},
 		},
 		{
 			name:        "explicit separator",


### PR DESCRIPTION
## Summary

- add project-level build-time container customization via `[customize]`
- support simple `packages = [...]` apt installs and optional Dockerfile fragments
- build and reuse derived images automatically, with BuildKit cache mounts for faster rebuilds
- document the upgrade/drift tradeoffs between project-level customization and fully custom images

## Verification

- `go test ./...`
- `./yolobox run --packages cowsay /usr/games/cowsay hello`
- reran the same `--packages` customization and confirmed image reuse
- tested `.yolobox.Dockerfile` fragment customization with `figlet` and confirmed cached rerun

Closes #38
