### PR TITLE
Add readonly project file filtering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,3 +96,5 @@ Also update [README.md](README.md) when user-facing behavior changes.
 - Avoid parallel Git commands in this repo while another Git operation is active. We have repeatedly hit misleading `.git/index.lock` failures from overlapping status/checkout/rebase calls.
 - GitHub Pages deployments that use a custom Actions workflow should set the custom domain in the repository Pages settings. A checked-in `CNAME` file is ignored in that flow and only adds confusion.
 - For the VitePress docs site, stop the live dev container before running `npm run docs:build`. The dev server and build both write `docs/.vitepress/dist`, and the shared bind mount causes flaky build conflicts if both are active.
+- Docker file bind mounts targeting a path inside an already bind-mounted project tree degrade into directories. Project file filtering must use a staged readonly project view rather than nested file mounts.
+- When yolobox itself runs inside another yolobox, temp mount sources must live under an existing host-visible bind mount like the project path. Inner-container `/tmp` is not visible to the outer Docker daemon.

--- a/README.md
+++ b/README.md
@@ -194,6 +194,9 @@ You can also create `.yolobox.toml` in your project for project-specific setting
 ```toml
 mounts = ["../shared-libs:/libs:ro"]
 env = ["DEBUG=1"]
+readonly_project = true
+exclude = [".env*", "secrets/**"]
+copy_as = [".env.sandbox:.env"]
 no_network = true
 shm_size = "2g"
 ```
@@ -203,6 +206,26 @@ Priority: CLI flags > project config > global config > defaults.
 Each `runtime_args` entry is a single CLI argument. For flags that take a value, add them as separate entries so `--security-opt seccomp=unconfined` becomes `["--security-opt", "seccomp=unconfined"]`.
 
 > **Note:** Setting `claude_config = true` or `gemini_config = true` in your config will copy your host config on **every** container start, overwriting any changes made inside the container (including auth and history). Prefer using `--claude-config` or `--gemini-config` for one-time syncs.
+
+### Project File Filtering
+
+Use `--exclude` to hide matching project paths from the container by staging an empty readonly project view:
+
+```bash
+yolobox claude --readonly-project --exclude ".env*" --exclude "secrets/**"
+```
+
+Use `--copy-as` to copy one file into another project path inside that staged readonly view:
+
+```bash
+yolobox claude --readonly-project --exclude ".env*" --copy-as ".env.sandbox:.env"
+```
+
+- `exclude` patterns are relative to the project root and support `**`
+- `copy_as` destinations must stay inside the project and must already exist as files
+- `copy_as` wins if it targets the same path as an `exclude`
+- `--exclude` and `--copy-as` currently require `--readonly-project`
+- `--exclude` and `--copy-as` are currently supported on Docker and Podman, not Apple's `container` runtime
 
 ### Copying Global Agent Instructions
 
@@ -242,6 +265,8 @@ These are automatically passed into the container if set:
 | `--runtime <name>` | Use `docker`, `podman`, or `container` (Apple) |
 | `--image <name>` | Custom base image |
 | `--mount <src:dst>` | Extra mount (repeatable) |
+| `--exclude <glob>` | Hide matching project paths from the container (repeatable) |
+| `--copy-as <src:dst>` | Mount a file at another project path inside the container (repeatable) |
 | `--env <KEY=val>` | Set environment variable (repeatable) |
 | `--setup` | Run interactive setup before starting |
 | `--ssh-agent` | Forward SSH agent socket |
@@ -276,6 +301,8 @@ These are automatically passed into the container if set:
 > **Networking:** By default, yolobox uses Docker's bridge network (internet access, no container DNS). Use `--network <name>` to join a docker compose network and access services by name. Use `--no-network` for complete isolation.
 
 > **Docker access:** The `--docker` flag mounts the host Docker socket into the container and joins a shared `yolobox-net` network. This lets the AI agent run Docker commands (build images, start containers, use docker compose) that create sibling containers on the same network. The agent and any services it creates can communicate by container name. The network name is available inside the container as `$YOLOBOX_NETWORK`. Cannot be used with `--no-network`.
+
+> **Project filtering:** `--exclude` globs are evaluated relative to the project root. `--copy-as` destinations must already exist as files in the project. Both flags currently require `--readonly-project`. Apple's `container` runtime does not support them yet.
 
 ## Philosophy: It's the AI's Box, Not Yours
 
@@ -328,6 +355,8 @@ If you're worried about an AI actively trying to escape containment, you need VM
 - The container itself (the AI has root via sudo)
 - Against kernel exploits or container escape vulnerabilities
 
+If you want a narrower view of the project, use `--exclude` and `--copy-as` to hide or replace selected files before the agent sees them.
+
 ### Hardening Options
 
 **Level 1: Basic (default)**
@@ -337,7 +366,7 @@ yolobox  # Standard container isolation
 
 **Level 2: Reduced attack surface**
 ```bash
-yolobox run --no-network --readonly-project claude
+yolobox claude --no-network --readonly-project --exclude ".env*" --exclude "secrets/**"
 ```
 
 **Level 3: Rootless Podman** (recommended for security-conscious users)

--- a/cmd/yolobox/main.go
+++ b/cmd/yolobox/main.go
@@ -1977,7 +1977,7 @@ func buildRunArgs(cfg Config, projectDir string, command []string, interactive b
 		args = append(args, "-e", env)
 	}
 
-	projectMountSource, projectOverlayMounts, overlayCleanupPaths, err := buildProjectFilterMounts(cfg, absProject)
+	projectMountSource, overlayCleanupPaths, err := buildProjectFilterMounts(cfg, absProject)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2193,10 +2193,6 @@ func buildRunArgs(cfg Config, projectDir string, command []string, interactive b
 		args = append(args, "-v", resolved)
 	}
 
-	for _, mount := range projectOverlayMounts {
-		args = append(args, "-v", formatProjectOverlayMount(mount))
-	}
-
 	// Resource & security controls
 	args = appendRunFlag(args, "cpus", cfg.CPUs)
 	args = appendRunFlag(args, "memory", cfg.Memory)
@@ -2318,12 +2314,6 @@ type projectCopyAsSpec struct {
 	src string
 	dst string
 	rel string
-}
-
-type projectOverlayMount struct {
-	src      string
-	dst      string
-	readOnly bool
 }
 
 func resolveHostPath(path string, projectDir string) (string, error) {
@@ -2551,14 +2541,14 @@ func parseCopyAsSpec(spec string, projectDir string) (projectCopyAsSpec, error) 
 	return projectCopyAsSpec{src: src, dst: dst, rel: filepath.ToSlash(rel)}, nil
 }
 
-func buildProjectFilterMounts(cfg Config, projectDir string) (string, []projectOverlayMount, []string, error) {
+func buildProjectFilterMounts(cfg Config, projectDir string) (string, []string, error) {
 	if len(cfg.Exclude) == 0 && len(cfg.CopyAs) == 0 {
-		return projectDir, nil, nil, nil
+		return projectDir, nil, nil
 	}
 
 	excludedPaths, err := resolveExcludedProjectPaths(cfg.Exclude, projectDir)
 	if err != nil {
-		return "", nil, nil, err
+		return "", nil, err
 	}
 
 	excludedByRel := make(map[string]projectPathInfo, len(excludedPaths))
@@ -2574,7 +2564,7 @@ func buildProjectFilterMounts(cfg Config, projectDir string) (string, []projectO
 	for _, rawSpec := range cfg.CopyAs {
 		spec, err := parseCopyAsSpec(rawSpec, projectDir)
 		if err != nil {
-			return "", nil, nil, err
+			return "", nil, err
 		}
 		copyAsByRel[spec.rel] = spec
 		for parent := path.Dir(spec.rel); parent != "." && parent != "/"; parent = path.Dir(parent) {
@@ -2584,7 +2574,7 @@ func buildProjectFilterMounts(cfg Config, projectDir string) (string, []projectO
 
 	viewRoot, err := os.MkdirTemp(projectDir, ".yolobox-project-view-*")
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("failed to create temp dir for project filtering: %w", err)
+		return "", nil, fmt.Errorf("failed to create temp dir for project filtering: %w", err)
 	}
 	cleanupPaths := []string{viewRoot}
 	viewRootBase := filepath.Base(viewRoot)
@@ -2668,17 +2658,10 @@ func buildProjectFilterMounts(cfg Config, projectDir string) (string, []projectO
 	}
 
 	if err := buildDir(projectDir, ""); err != nil {
-		return "", nil, cleanupPaths, err
+		return "", cleanupPaths, err
 	}
 
-	return viewRoot, nil, cleanupPaths, nil
-}
-
-func formatProjectOverlayMount(mount projectOverlayMount) string {
-	if mount.readOnly {
-		return mount.src + ":" + mount.dst + ":ro"
-	}
-	return mount.src + ":" + mount.dst
+	return viewRoot, cleanupPaths, nil
 }
 
 func resolvedRuntimeName(name string) string {

--- a/cmd/yolobox/main.go
+++ b/cmd/yolobox/main.go
@@ -9,9 +9,11 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -87,6 +89,8 @@ type Config struct {
 	Image                 string   `toml:"image"`
 	Mounts                []string `toml:"mounts"`
 	Env                   []string `toml:"env"`
+	Exclude               []string `toml:"exclude"`
+	CopyAs                []string `toml:"copy_as"`
 	SSHAgent              bool     `toml:"ssh_agent"`
 	ReadonlyProject       bool     `toml:"readonly_project"`
 	NoNetwork             bool     `toml:"no_network"`
@@ -421,6 +425,8 @@ func printUsage() {
 	fmt.Fprintln(os.Stderr, "  --pod <name>          Join existing Podman pod (shares its network)")
 	fmt.Fprintln(os.Stderr, "  --setup               Run interactive setup before starting")
 	fmt.Fprintln(os.Stderr, "  --mount <src:dst>     Extra mount (repeatable)")
+	fmt.Fprintln(os.Stderr, "  --exclude <glob>      Hide project paths from the container (repeatable)")
+	fmt.Fprintln(os.Stderr, "  --copy-as <src:dst>   Mount a file at a project path inside the container")
 	fmt.Fprintln(os.Stderr, "  --env <KEY=val>       Set environment variable (repeatable)")
 	fmt.Fprintln(os.Stderr, "  --ssh-agent           Forward SSH agent socket")
 	fmt.Fprintln(os.Stderr, "  --no-network          Disable network access (default: network enabled)")
@@ -495,6 +501,8 @@ func parseBaseFlags(name string, args []string, projectDir string) (Config, []st
 		docker                bool
 		setup                 bool
 		mounts                stringSliceFlag
+		excludes              stringSliceFlag
+		copyAs                stringSliceFlag
 		envVars               stringSliceFlag
 
 		// Resource limits & security
@@ -528,6 +536,8 @@ func parseBaseFlags(name string, args []string, projectDir string) (Config, []st
 	fs.BoolVar(&docker, "docker", false, "mount Docker socket and join shared network")
 	fs.BoolVar(&setup, "setup", false, "run interactive setup before starting")
 	fs.Var(&mounts, "mount", "extra mount src:dst")
+	fs.Var(&excludes, "exclude", "hide matching project paths from the container")
+	fs.Var(&copyAs, "copy-as", "mount a file at another project path inside the container")
 	fs.Var(&envVars, "env", "environment variable KEY=value")
 
 	// Resource limits & security
@@ -602,6 +612,12 @@ func parseBaseFlags(name string, args []string, projectDir string) (Config, []st
 	if len(mounts) > 0 {
 		cfg.Mounts = append(cfg.Mounts, mounts...)
 	}
+	if len(excludes) > 0 {
+		cfg.Exclude = append(cfg.Exclude, excludes...)
+	}
+	if len(copyAs) > 0 {
+		cfg.CopyAs = append(cfg.CopyAs, copyAs...)
+	}
 	if len(envVars) > 0 {
 		cfg.Env = append(cfg.Env, envVars...)
 	}
@@ -649,6 +665,9 @@ func parseBaseFlags(name string, args []string, projectDir string) (Config, []st
 		return cfg, nil, err
 	}
 	if err := validateCustomizeConfig(cfg.Customize); err != nil {
+		return cfg, nil, err
+	}
+	if err := validateProjectFilteringConfig(cfg, projectDir); err != nil {
 		return cfg, nil, err
 	}
 
@@ -720,6 +739,21 @@ func validateRuntimeOptions(cfg Config) error {
 		}
 	}
 
+	return nil
+}
+
+func validateProjectFilteringConfig(cfg Config, projectDir string) error {
+	if (len(cfg.Exclude) > 0 || len(cfg.CopyAs) > 0) && !cfg.ReadonlyProject {
+		return fmt.Errorf("--exclude and --copy-as currently require --readonly-project")
+	}
+	if _, err := resolveExcludedProjectPaths(cfg.Exclude, projectDir); err != nil {
+		return err
+	}
+	for _, spec := range cfg.CopyAs {
+		if _, err := parseCopyAsSpec(spec, projectDir); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -828,6 +862,12 @@ func mergeConfig(dst *Config, src Config) {
 	}
 	if len(src.Env) > 0 {
 		dst.Env = append([]string{}, src.Env...)
+	}
+	if len(src.Exclude) > 0 {
+		dst.Exclude = append([]string{}, src.Exclude...)
+	}
+	if len(src.CopyAs) > 0 {
+		dst.CopyAs = append([]string{}, src.CopyAs...)
 	}
 	if src.SSHAgent {
 		dst.SSHAgent = true
@@ -1016,6 +1056,8 @@ func printConfig(cfg Config) error {
 	printSliceConfigField("runtime_args", cfg.RuntimeArgs)
 	printSliceConfigField("customize.packages", cfg.Customize.Packages)
 	printStringConfigField("customize.dockerfile", cfg.Customize.Dockerfile)
+	printSliceConfigField("exclude", cfg.Exclude)
+	printSliceConfigField("copy_as", cfg.CopyAs)
 
 	if len(cfg.Mounts) > 0 {
 		fmt.Printf("%smounts:%s\n", colorBold, colorReset)
@@ -1074,6 +1116,12 @@ func saveGlobalConfig(cfg Config) error {
 	}
 	if cfg.GhToken {
 		lines = append(lines, "gh_token = true")
+	}
+	if len(cfg.Exclude) > 0 {
+		lines = append(lines, fmt.Sprintf("exclude = %s", formatTomlStringSlice(cfg.Exclude)))
+	}
+	if len(cfg.CopyAs) > 0 {
+		lines = append(lines, fmt.Sprintf("copy_as = %s", formatTomlStringSlice(cfg.CopyAs)))
 	}
 	if cfg.SSHAgent {
 		lines = append(lines, "ssh_agent = true")
@@ -1387,6 +1435,7 @@ func splitToolArgs(args []string) (yoloboxArgs, toolArgs []string) {
 		"no-yolo": true, "scratch": true, "claude-config": true,
 		"gemini-config": true, "git-config": true, "gh-token": true,
 		"copy-agent-instructions": true, "docker": true, "setup": true, "mount": true,
+		"exclude": true, "copy-as": true,
 		"env": true, "h": true, "help": true,
 		"cpus": true, "memory": true, "shm-size": true, "gpus": true,
 		"device": true, "cap-add": true, "cap-drop": true, "runtime-arg": true,
@@ -1395,7 +1444,7 @@ func splitToolArgs(args []string) (yoloboxArgs, toolArgs []string) {
 
 	flagsWithValues := map[string]bool{
 		"runtime": true, "image": true, "network": true, "pod": true,
-		"mount": true, "env": true, "cpus": true, "memory": true,
+		"mount": true, "exclude": true, "copy-as": true, "env": true, "cpus": true, "memory": true,
 		"shm-size": true, "device": true, "cap-add": true, "cap-drop": true,
 		"gpus": true, "runtime-arg": true, "packages": true, "customize-file": true,
 	}
@@ -1856,6 +1905,9 @@ func buildRunArgs(cfg Config, projectDir string, command []string, interactive b
 
 	// Check if we're using Apple container (doesn't support file mounts)
 	appleContainer := isAppleContainer(cfg.Runtime)
+	if appleContainer && (len(cfg.Exclude) > 0 || len(cfg.CopyAs) > 0) {
+		return nil, nil, fmt.Errorf("--exclude and --copy-as are not supported with Apple container runtime")
+	}
 
 	// Check if we're using rootless Podman (needs --userns=keep-id for bind mount permissions)
 	rootlessPodman := isRootlessPodman(cfg.Runtime)
@@ -1925,9 +1977,15 @@ func buildRunArgs(cfg Config, projectDir string, command []string, interactive b
 		args = append(args, "-e", env)
 	}
 
+	projectMountSource, projectOverlayMounts, overlayCleanupPaths, err := buildProjectFilterMounts(cfg, absProject)
+	if err != nil {
+		return nil, nil, err
+	}
+	cleanupPaths = append(cleanupPaths, overlayCleanupPaths...)
+
 	// Project mount at its real host path (for session continuity)
 	// A symlink /workspace -> real path is created by the entrypoint
-	projectMount := absProject + ":" + absProject
+	projectMount := projectMountSource + ":" + absProject
 	if cfg.ReadonlyProject {
 		projectMount += ":ro"
 		// Create a writable output directory
@@ -2135,6 +2193,10 @@ func buildRunArgs(cfg Config, projectDir string, command []string, interactive b
 		args = append(args, "-v", resolved)
 	}
 
+	for _, mount := range projectOverlayMounts {
+		args = append(args, "-v", formatProjectOverlayMount(mount))
+	}
+
 	// Resource & security controls
 	args = appendRunFlag(args, "cpus", cfg.CPUs)
 	args = appendRunFlag(args, "memory", cfg.Memory)
@@ -2244,6 +2306,379 @@ func resolvePath(path string, projectDir string) (string, error) {
 		return filepath.Clean(path), nil
 	}
 	return path, nil
+}
+
+type projectPathInfo struct {
+	abs   string
+	rel   string
+	isDir bool
+}
+
+type projectCopyAsSpec struct {
+	src string
+	dst string
+	rel string
+}
+
+type projectOverlayMount struct {
+	src      string
+	dst      string
+	readOnly bool
+}
+
+func resolveHostPath(path string, projectDir string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("empty path")
+	}
+	if strings.HasPrefix(path, "~") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		if path == "~" {
+			path = home
+		} else if strings.HasPrefix(path, "~/") {
+			path = filepath.Join(home, path[2:])
+		}
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(projectDir, path)
+	}
+	return filepath.Clean(path), nil
+}
+
+func resolveProjectRelativeTarget(target string, projectDir string) (string, error) {
+	target = filepath.ToSlash(strings.TrimSpace(target))
+	if target == "" {
+		return "", fmt.Errorf("empty project path")
+	}
+	if strings.HasPrefix(target, "~") {
+		return "", fmt.Errorf("project path %q must be relative to the project root", target)
+	}
+	cleanTarget := path.Clean(strings.TrimPrefix(target, "./"))
+	if cleanTarget == "." || cleanTarget == ".." || strings.HasPrefix(cleanTarget, "../") {
+		return "", fmt.Errorf("project path %q escapes the project root", target)
+	}
+	if path.IsAbs(cleanTarget) {
+		return "", fmt.Errorf("project path %q must be relative to the project root", target)
+	}
+	return filepath.Join(projectDir, filepath.FromSlash(cleanTarget)), nil
+}
+
+func normalizeProjectPattern(pattern string) (string, error) {
+	pattern = filepath.ToSlash(strings.TrimSpace(pattern))
+	if pattern == "" {
+		return "", fmt.Errorf("exclude patterns cannot be blank")
+	}
+	if strings.HasPrefix(pattern, "~") {
+		return "", fmt.Errorf("exclude pattern %q must be relative to the project root", pattern)
+	}
+	cleanPattern := path.Clean(strings.TrimPrefix(pattern, "./"))
+	if cleanPattern == "." || cleanPattern == ".." || strings.HasPrefix(cleanPattern, "../") {
+		return "", fmt.Errorf("exclude pattern %q escapes the project root", pattern)
+	}
+	if path.IsAbs(cleanPattern) {
+		return "", fmt.Errorf("exclude pattern %q must be relative to the project root", pattern)
+	}
+	for _, segment := range strings.Split(cleanPattern, "/") {
+		if segment == "**" {
+			continue
+		}
+		if _, err := path.Match(segment, ""); err != nil {
+			return "", fmt.Errorf("invalid exclude pattern %q: %w", pattern, err)
+		}
+	}
+	return cleanPattern, nil
+}
+
+func matchProjectPattern(pattern, rel string) bool {
+	return matchProjectPatternSegments(strings.Split(pattern, "/"), strings.Split(rel, "/"))
+}
+
+func matchProjectPatternSegments(patternSegments, pathSegments []string) bool {
+	if len(patternSegments) == 0 {
+		return len(pathSegments) == 0
+	}
+	if patternSegments[0] == "**" {
+		if len(patternSegments) == 1 {
+			return true
+		}
+		if matchProjectPatternSegments(patternSegments[1:], pathSegments) {
+			return true
+		}
+		for i := range pathSegments {
+			if matchProjectPatternSegments(patternSegments[1:], pathSegments[i+1:]) {
+				return true
+			}
+		}
+		return false
+	}
+	if len(pathSegments) == 0 {
+		return false
+	}
+	matched, err := path.Match(patternSegments[0], pathSegments[0])
+	if err != nil || !matched {
+		return false
+	}
+	return matchProjectPatternSegments(patternSegments[1:], pathSegments[1:])
+}
+
+func collectProjectPaths(projectDir string) ([]projectPathInfo, error) {
+	var paths []projectPathInfo
+	err := filepath.WalkDir(projectDir, func(current string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if current == projectDir {
+			return nil
+		}
+		rel, err := filepath.Rel(projectDir, current)
+		if err != nil {
+			return err
+		}
+		paths = append(paths, projectPathInfo{
+			abs:   current,
+			rel:   filepath.ToSlash(rel),
+			isDir: entry.IsDir(),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(paths, func(i, j int) bool {
+		if paths[i].rel == paths[j].rel {
+			return !paths[i].isDir && paths[j].isDir
+		}
+		return paths[i].rel < paths[j].rel
+	})
+	return paths, nil
+}
+
+func resolveExcludedProjectPaths(patterns []string, projectDir string) ([]projectPathInfo, error) {
+	if len(patterns) == 0 {
+		return nil, nil
+	}
+	projectPaths, err := collectProjectPaths(projectDir)
+	if err != nil {
+		return nil, err
+	}
+
+	matchedByTarget := make(map[string]projectPathInfo)
+	for _, rawPattern := range patterns {
+		pattern, err := normalizeProjectPattern(rawPattern)
+		if err != nil {
+			return nil, err
+		}
+		for _, candidate := range projectPaths {
+			if matchProjectPattern(pattern, candidate.rel) {
+				matchedByTarget[candidate.abs] = candidate
+			}
+		}
+	}
+
+	matches := make([]projectPathInfo, 0, len(matchedByTarget))
+	for _, candidate := range matchedByTarget {
+		matches = append(matches, candidate)
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		depthI := strings.Count(matches[i].rel, "/")
+		depthJ := strings.Count(matches[j].rel, "/")
+		if depthI != depthJ {
+			return depthI < depthJ
+		}
+		return matches[i].rel < matches[j].rel
+	})
+
+	var pruned []projectPathInfo
+	excludedDirs := make(map[string]bool)
+	for _, candidate := range matches {
+		if hasExcludedAncestor(candidate.rel, excludedDirs) {
+			continue
+		}
+		pruned = append(pruned, candidate)
+		if candidate.isDir {
+			excludedDirs[candidate.rel] = true
+		}
+	}
+	return pruned, nil
+}
+
+func hasExcludedAncestor(rel string, excludedDirs map[string]bool) bool {
+	for parent := path.Dir(rel); parent != "." && parent != "/"; parent = path.Dir(parent) {
+		if excludedDirs[parent] {
+			return true
+		}
+	}
+	return false
+}
+
+func parseCopyAsSpec(spec string, projectDir string) (projectCopyAsSpec, error) {
+	parts := strings.SplitN(spec, ":", 2)
+	if len(parts) != 2 {
+		return projectCopyAsSpec{}, fmt.Errorf("invalid copy-as %q; expected src:dst", spec)
+	}
+	src, err := resolveHostPath(strings.TrimSpace(parts[0]), projectDir)
+	if err != nil {
+		return projectCopyAsSpec{}, err
+	}
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return projectCopyAsSpec{}, fmt.Errorf("copy-as source %q: %w", parts[0], err)
+	}
+	if srcInfo.IsDir() {
+		return projectCopyAsSpec{}, fmt.Errorf("copy-as source %q must be a file, not a directory", parts[0])
+	}
+
+	dst, err := resolveProjectRelativeTarget(parts[1], projectDir)
+	if err != nil {
+		return projectCopyAsSpec{}, err
+	}
+	dstInfo, err := os.Lstat(dst)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return projectCopyAsSpec{}, fmt.Errorf("copy-as destination %q must already exist as a file in the project", parts[1])
+		}
+		return projectCopyAsSpec{}, fmt.Errorf("copy-as destination %q: %w", parts[1], err)
+	}
+	if dstInfo.IsDir() {
+		return projectCopyAsSpec{}, fmt.Errorf("copy-as destination %q must be a file path, not a directory", parts[1])
+	}
+	rel, err := filepath.Rel(projectDir, dst)
+	if err != nil {
+		return projectCopyAsSpec{}, err
+	}
+	return projectCopyAsSpec{src: src, dst: dst, rel: filepath.ToSlash(rel)}, nil
+}
+
+func buildProjectFilterMounts(cfg Config, projectDir string) (string, []projectOverlayMount, []string, error) {
+	if len(cfg.Exclude) == 0 && len(cfg.CopyAs) == 0 {
+		return projectDir, nil, nil, nil
+	}
+
+	excludedPaths, err := resolveExcludedProjectPaths(cfg.Exclude, projectDir)
+	if err != nil {
+		return "", nil, nil, err
+	}
+
+	excludedByRel := make(map[string]projectPathInfo, len(excludedPaths))
+	specialAncestorDirs := make(map[string]bool)
+	for _, excluded := range excludedPaths {
+		excludedByRel[excluded.rel] = excluded
+		for parent := path.Dir(excluded.rel); parent != "." && parent != "/"; parent = path.Dir(parent) {
+			specialAncestorDirs[parent] = true
+		}
+	}
+
+	copyAsByRel := make(map[string]projectCopyAsSpec, len(cfg.CopyAs))
+	for _, rawSpec := range cfg.CopyAs {
+		spec, err := parseCopyAsSpec(rawSpec, projectDir)
+		if err != nil {
+			return "", nil, nil, err
+		}
+		copyAsByRel[spec.rel] = spec
+		for parent := path.Dir(spec.rel); parent != "." && parent != "/"; parent = path.Dir(parent) {
+			specialAncestorDirs[parent] = true
+		}
+	}
+
+	viewRoot, err := os.MkdirTemp(projectDir, ".yolobox-project-view-*")
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("failed to create temp dir for project filtering: %w", err)
+	}
+	cleanupPaths := []string{viewRoot}
+	viewRootBase := filepath.Base(viewRoot)
+
+	var buildDir func(hostDir, relDir string) error
+	buildDir = func(hostDir, relDir string) error {
+		entries, err := os.ReadDir(hostDir)
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			if relDir == "" && entry.Name() == viewRootBase {
+				continue
+			}
+			relPath := entry.Name()
+			if relDir != "" {
+				relPath = path.Join(relDir, entry.Name())
+			}
+			targetPath := filepath.Join(viewRoot, filepath.FromSlash(relPath))
+			hostPath := filepath.Join(hostDir, entry.Name())
+
+			if spec, ok := copyAsByRel[relPath]; ok {
+				if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+					return err
+				}
+				data, err := os.ReadFile(spec.src)
+				if err != nil {
+					return err
+				}
+				if err := os.WriteFile(targetPath, data, 0644); err != nil {
+					return err
+				}
+				continue
+			}
+
+			if excluded, ok := excludedByRel[relPath]; ok {
+				if excluded.isDir {
+					if err := os.MkdirAll(targetPath, 0755); err != nil {
+						return err
+					}
+				} else {
+					if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+						return err
+					}
+					file, err := os.OpenFile(targetPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+					if err != nil {
+						return err
+					}
+					if err := file.Close(); err != nil {
+						return err
+					}
+				}
+				continue
+			}
+
+			if entry.IsDir() {
+				if err := os.MkdirAll(targetPath, 0755); err != nil {
+					return err
+				}
+				if specialAncestorDirs[relPath] {
+					if err := buildDir(hostPath, relPath); err != nil {
+						return err
+					}
+					continue
+				}
+				continue
+			}
+
+			if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+				return err
+			}
+			file, err := os.OpenFile(targetPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+			if err != nil {
+				return err
+			}
+			if err := file.Close(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if err := buildDir(projectDir, ""); err != nil {
+		return "", nil, cleanupPaths, err
+	}
+
+	return viewRoot, nil, cleanupPaths, nil
+}
+
+func formatProjectOverlayMount(mount projectOverlayMount) string {
+	if mount.readOnly {
+		return mount.src + ":" + mount.dst + ":ro"
+	}
+	return mount.src + ":" + mount.dst
 }
 
 func resolvedRuntimeName(name string) string {

--- a/cmd/yolobox/main_test.go
+++ b/cmd/yolobox/main_test.go
@@ -70,6 +70,19 @@ func TestMergeConfigCustomize(t *testing.T) {
 	}
 }
 
+func TestMergeConfigProjectFiltering(t *testing.T) {
+	dst := Config{}
+	src := Config{
+		Exclude: []string{".env*", "secrets/**"},
+		CopyAs:  []string{".env.sandbox:.env"},
+	}
+
+	mergeConfig(&dst, src)
+
+	expectSliceEqual(t, dst.Exclude, []string{".env*", "secrets/**"})
+	expectSliceEqual(t, dst.CopyAs, []string{".env.sandbox:.env"})
+}
+
 func TestLoadSetupDefaultsIgnoresProjectConfig(t *testing.T) {
 	projectDir := t.TempDir()
 	configHome := t.TempDir()
@@ -178,6 +191,30 @@ func TestResolveMountInvalid(t *testing.T) {
 	_, err := resolveMount("no-colon", "/project")
 	if err == nil {
 		t.Error("expected error for invalid mount")
+	}
+}
+
+func TestMatchProjectPattern(t *testing.T) {
+	tests := []struct {
+		pattern string
+		rel     string
+		want    bool
+	}{
+		{pattern: ".env*", rel: ".env", want: true},
+		{pattern: ".env*", rel: "config/.env", want: false},
+		{pattern: "secrets/**", rel: "secrets", want: true},
+		{pattern: "secrets/**", rel: "secrets/nested/token.txt", want: true},
+		{pattern: "**/*.pem", rel: "certs/dev/key.pem", want: true},
+		{pattern: "**/*.pem", rel: "certs/dev/key.txt", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"::"+tt.rel, func(t *testing.T) {
+			got := matchProjectPattern(tt.pattern, tt.rel)
+			if got != tt.want {
+				t.Fatalf("matchProjectPattern(%q, %q) = %t, want %t", tt.pattern, tt.rel, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -378,6 +415,127 @@ func TestBuildRunArgsReadonlyProject(t *testing.T) {
 	}
 }
 
+func TestBuildRunArgsProjectFiltering(t *testing.T) {
+	projectDir := t.TempDir()
+	envPath := filepath.Join(projectDir, ".env")
+	sandboxPath := filepath.Join(projectDir, ".env.sandbox")
+	secretsDir := filepath.Join(projectDir, "secrets")
+
+	if err := os.WriteFile(envPath, []byte("REAL=1\n"), 0644); err != nil {
+		t.Fatalf("failed to write %s: %v", envPath, err)
+	}
+	if err := os.WriteFile(sandboxPath, []byte("SANDBOX=1\n"), 0644); err != nil {
+		t.Fatalf("failed to write %s: %v", sandboxPath, err)
+	}
+	if err := os.MkdirAll(secretsDir, 0755); err != nil {
+		t.Fatalf("failed to create secrets dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(secretsDir, "token.txt"), []byte("secret"), 0644); err != nil {
+		t.Fatalf("failed to write secret file: %v", err)
+	}
+
+	cfg := Config{
+		Image:           "test-image",
+		ReadonlyProject: true,
+		Exclude:         []string{".env*", "secrets/**"},
+		CopyAs:          []string{".env.sandbox:.env"},
+	}
+
+	args, cleanupPaths, err := buildRunArgs(cfg, projectDir, []string{"bash"}, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cleanupPaths) == 0 {
+		t.Fatal("expected cleanup paths for staged filtered project view")
+	}
+	viewRoot := cleanupPaths[0]
+
+	argsStr := strings.Join(args, " ")
+	if !strings.Contains(argsStr, viewRoot+":"+projectDir+":ro") {
+		t.Fatalf("expected filtered project root mount from %s to %s, got %s", viewRoot, projectDir, argsStr)
+	}
+	if strings.Contains(argsStr, sandboxPath+":"+envPath) {
+		t.Fatalf("did not expect nested copy-as mount in filtered readonly mode, got %s", argsStr)
+	}
+	if placeholder, err := os.ReadFile(filepath.Join(viewRoot, ".env.sandbox")); err != nil {
+		t.Fatalf("expected excluded sandbox placeholder file: %v", err)
+	} else if len(placeholder) != 0 {
+		t.Fatalf("expected excluded sandbox placeholder to be empty, got %q", string(placeholder))
+	}
+	if entries, err := os.ReadDir(filepath.Join(viewRoot, "secrets")); err != nil {
+		t.Fatalf("expected excluded secrets placeholder dir: %v", err)
+	} else if len(entries) != 0 {
+		t.Fatalf("expected excluded secrets placeholder dir to be empty, got %d entries", len(entries))
+	}
+	if replacement, err := os.ReadFile(filepath.Join(viewRoot, ".env")); err != nil {
+		t.Fatalf("expected copy-as destination in filtered view: %v", err)
+	} else if string(replacement) != "SANDBOX=1\n" {
+		t.Fatalf("expected copied replacement contents, got %q", string(replacement))
+	}
+}
+
+func TestBuildRunArgsProjectFilteringReadonlyProject(t *testing.T) {
+	projectDir := t.TempDir()
+	envPath := filepath.Join(projectDir, ".env")
+	sandboxPath := filepath.Join(projectDir, ".env.sandbox")
+
+	if err := os.WriteFile(envPath, []byte("REAL=1\n"), 0644); err != nil {
+		t.Fatalf("failed to write %s: %v", envPath, err)
+	}
+	if err := os.WriteFile(sandboxPath, []byte("SANDBOX=1\n"), 0644); err != nil {
+		t.Fatalf("failed to write %s: %v", sandboxPath, err)
+	}
+
+	cfg := Config{
+		Image:           "test-image",
+		ReadonlyProject: true,
+		CopyAs:          []string{".env.sandbox:.env"},
+	}
+
+	args, cleanupPaths, err := buildRunArgs(cfg, projectDir, []string{"bash"}, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	argsStr := strings.Join(args, " ")
+	if len(cleanupPaths) == 0 {
+		t.Fatal("expected staged readonly project view")
+	}
+	viewRoot := cleanupPaths[0]
+	if !strings.Contains(argsStr, viewRoot+":"+projectDir+":ro") {
+		t.Fatalf("expected readonly staged project mount, got %s", argsStr)
+	}
+	if replacement, err := os.ReadFile(filepath.Join(viewRoot, ".env")); err != nil {
+		t.Fatalf("expected copied replacement file: %v", err)
+	} else if string(replacement) != "SANDBOX=1\n" {
+		t.Fatalf("unexpected replacement contents: %q", string(replacement))
+	}
+}
+
+func TestBuildRunArgsProjectFilteringAppleRuntimeUnsupported(t *testing.T) {
+	projectDir := t.TempDir()
+	runtimeDir := t.TempDir()
+	containerPath := filepath.Join(runtimeDir, "container")
+	if err := os.WriteFile(containerPath, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatalf("failed to write fake container runtime: %v", err)
+	}
+	t.Setenv("PATH", runtimeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cfg := Config{
+		Runtime: "container",
+		Image:   "test-image",
+		Exclude: []string{".env*"},
+	}
+
+	_, _, err := buildRunArgs(cfg, projectDir, []string{"bash"}, false)
+	if err == nil {
+		t.Fatal("expected Apple container runtime to reject file filtering")
+	}
+	if !strings.Contains(err.Error(), "not supported with Apple container runtime") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestBuildRunArgsNonInteractive(t *testing.T) {
 	cfg := Config{
 		Image: "test-image",
@@ -552,6 +710,60 @@ func TestParseFlagsCustomizeInvalidPackage(t *testing.T) {
 	_, _, err := parseBaseFlags("run", []string{"--packages", "default-jdk,$(evil)", "java"}, t.TempDir())
 	if err == nil {
 		t.Fatal("expected invalid package name error")
+	}
+}
+
+func TestParseFlagsProjectFiltering(t *testing.T) {
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, ".env"), []byte("REAL=1\n"), 0644); err != nil {
+		t.Fatalf("failed to write .env: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, ".env.sandbox"), []byte("SANDBOX=1\n"), 0644); err != nil {
+		t.Fatalf("failed to write .env.sandbox: %v", err)
+	}
+
+	cfg, rest, err := parseBaseFlags("run", []string{
+		"--readonly-project",
+		"--exclude", ".env*",
+		"--copy-as", ".env.sandbox:.env",
+		"env",
+	}, projectDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectSliceEqual(t, cfg.Exclude, []string{".env*"})
+	expectSliceEqual(t, cfg.CopyAs, []string{".env.sandbox:.env"})
+	expectSliceEqual(t, rest, []string{"env"})
+}
+
+func TestParseFlagsProjectFilteringRejectsMissingCopyAsDestination(t *testing.T) {
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, ".env.sandbox"), []byte("SANDBOX=1\n"), 0644); err != nil {
+		t.Fatalf("failed to write .env.sandbox: %v", err)
+	}
+
+	_, _, err := parseBaseFlags("run", []string{"--readonly-project", "--copy-as", ".env.sandbox:.env", "env"}, projectDir)
+	if err == nil {
+		t.Fatal("expected missing copy-as destination to fail")
+	}
+	if !strings.Contains(err.Error(), "must already exist as a file") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseFlagsProjectFilteringRequiresReadonlyProject(t *testing.T) {
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, ".env"), []byte("REAL=1\n"), 0644); err != nil {
+		t.Fatalf("failed to write .env: %v", err)
+	}
+
+	_, _, err := parseBaseFlags("run", []string{"--exclude", ".env*", "env"}, projectDir)
+	if err == nil {
+		t.Fatal("expected readonly-project requirement to fail")
+	}
+	if !strings.Contains(err.Error(), "require --readonly-project") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -1076,6 +1288,12 @@ func TestSplitToolArgs(t *testing.T) {
 			name:        "yolobox flag with equals then tool flag",
 			args:        []string{"--env=FOO=bar", "--resume"},
 			wantYolobox: []string{"--env=FOO=bar"},
+			wantTool:    []string{"--resume"},
+		},
+		{
+			name:        "project filtering flags stay with yolobox",
+			args:        []string{"--exclude", ".env*", "--copy-as", ".env.sandbox:.env", "--resume"},
+			wantYolobox: []string{"--exclude", ".env*", "--copy-as", ".env.sandbox:.env"},
 			wantTool:    []string{"--resume"},
 		},
 		{

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -56,6 +56,12 @@ yolobox claude --docker --git-config --gh-token
 yolobox run --no-network --readonly-project python3 untrusted_script.py
 ```
 
+### Hide secrets from the sandboxed view
+
+```bash
+yolobox claude --readonly-project --exclude ".env*" --exclude "secrets/**" --copy-as ".env.sandbox:.env"
+```
+
 ### Build with extra packages for one project
 
 ```bash

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,6 +36,9 @@ Place in your project root for project-specific settings:
 ```toml
 mounts = ["../shared-libs:/libs:ro"]
 env = ["DEBUG=1"]
+readonly_project = true
+exclude = [".env*", "secrets/**"]
+copy_as = [".env.sandbox:.env"]
 no_network = true
 shm_size = "2g"
 
@@ -46,6 +49,22 @@ packages = ["default-jdk", "maven"]
 ### Precedence
 
 CLI flags > project config > global config > defaults
+
+## Project file filtering
+
+Use project config when you want a repo to carry its own sandboxed view:
+
+```toml
+exclude = [".env*", "secrets/**"]
+copy_as = [".env.sandbox:.env"]
+```
+
+- `exclude` globs are relative to the project root and support `**`
+- `copy_as` sources can be relative or absolute host paths
+- `copy_as` destinations must stay inside the project and already exist as files
+- `copy_as` takes precedence if it targets the same path as `exclude`
+- both options currently require `readonly_project = true` or `--readonly-project`
+- Apple's `container` runtime does not support this feature yet
 
 ## Customization config
 

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -19,6 +19,8 @@ Flags go after the subcommand: `yolobox run --flag cmd` or `yolobox claude --fla
 | Flag | Description |
 |------|-------------|
 | `--mount <src:dst>` | Extra mount, repeatable |
+| `--exclude <glob>` | Hide matching project paths from the container, repeatable |
+| `--copy-as <src:dst>` | Mount a file at another project path inside the container, repeatable |
 | `--env <KEY=val>` | Extra environment variable, repeatable |
 | `--setup` | Run interactive setup before starting |
 | `--ssh-agent` | Forward SSH agent socket |
@@ -80,6 +82,30 @@ The network name is available inside the container as `$YOLOBOX_NETWORK`.
 
 ::: warning
 `--docker` cannot be combined with `--no-network`.
+:::
+
+## Project file filtering
+
+Use `--exclude` when you want the container to see an empty placeholder instead of the real project file or directory:
+
+```bash
+yolobox claude --readonly-project --exclude ".env*" --exclude "secrets/**"
+```
+
+Use `--copy-as` when you want to substitute one file for another project path inside the staged readonly project view:
+
+```bash
+yolobox claude --readonly-project --exclude ".env*" --copy-as ".env.sandbox:.env"
+```
+
+- exclude globs are relative to the project root
+- `**` matches recursively
+- `copy-as` destinations must stay inside the project and already exist as files
+- if both flags target the same path, `copy-as` wins
+- both flags currently require `--readonly-project`
+
+::: warning
+`--exclude` and `--copy-as` are currently supported on Docker and Podman only. Apple's `container` runtime does not support them yet.
 :::
 
 ## Derived image customization

--- a/docs/security.md
+++ b/docs/security.md
@@ -43,6 +43,8 @@ If you are defending against hostile code rather than careless code, move up to 
 - the container's own filesystem and state
 - the host from runtime or kernel escape vulnerabilities
 
+If you want to narrow the container's view of the project itself, use `--exclude` and `--copy-as` to hide or replace selected files before the agent sees them.
+
 ## Important trust-expanding flags
 
 Some flags deliberately widen the trust boundary:
@@ -66,7 +68,7 @@ Good for protection from accidental damage.
 ### Level 2: reduced attack surface
 
 ```bash
-yolobox claude --no-network --readonly-project
+yolobox claude --no-network --readonly-project --exclude ".env*" --exclude "secrets/**"
 ```
 
 Good when you want a tighter box for inspection or untrusted code.


### PR DESCRIPTION
## Summary
- add `--exclude` and `--copy-as` with `.yolobox.toml` support for readonly project filtering
- stage a filtered readonly project view so hidden files become empty placeholders and replacements are copied into the sandbox view
- document the new flags and constraints in the README, VitePress docs, and AGENTS hard learnings

## Verification
- make clean && make build && make test
- npm run docs:build
- ./yolobox version
- ./yolobox help
- ./yolobox config
- created a temp project under the repo mount and ran `./yolobox run --readonly-project --exclude .env* --exclude secrets/** --copy-as .env.sandbox:.env ...` to verify `.env` is replaced, `.env.sandbox` is hidden, and `secrets/token.txt` is not visible

Closes #34