### PR TITLE
Add --no-project flag to skip automatic project mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,19 @@ yolobox claude --readonly-project --exclude ".env*" --copy-as ".env.sandbox:.env
 - `--exclude` and `--copy-as` currently require `--readonly-project`
 - `--exclude` and `--copy-as` are currently supported on Docker and Podman, not Apple's `container` runtime
 
+### Skipping the Automatic Project Mount
+
+Use `--no-project` when yolobox is running in an environment where its current working directory is not also visible to the Docker or Podman daemon, such as some Docker-in-Docker and remote-daemon setups. This skips the default project mount, default workdir, and `$YOLOBOX_PROJECT_PATH`; provide your own mount and workdir explicitly:
+
+```bash
+yolobox run --no-project \
+  --mount /host/path/to/project:/workspace \
+  --runtime-arg=--workdir=/workspace \
+  bash
+```
+
+`--no-project` is incompatible with `--readonly-project`, `--exclude`, and `--copy-as` because those options operate on the automatic project mount.
+
 ### Copying Global Agent Instructions
 
 The `--copy-agent-instructions` flag copies your **global/user-level** agent instruction files and skills into the container. This is useful when you have custom rules, preferences, or reusable skills defined globally that you want available inside yolobox.
@@ -361,7 +374,7 @@ Both skills follow the standard Agent Skills layout so they can be validated and
 
 > **Clipboard bridge:** `--clipboard` starts a short-lived host proxy and exposes text clipboard command shims (`pbcopy`, `pbpaste`, `xclip`, `xsel`, `wl-copy`, `wl-paste`) inside the container.
 
-> **Project filtering:** `--exclude` globs are evaluated relative to the project root. `--copy-as` destinations must already exist as files in the project. Both flags currently require `--readonly-project`. Apple's `container` runtime does not support them yet.
+> **Project filtering:** `--exclude` globs are evaluated relative to the project root. `--copy-as` destinations must already exist as files in the project. Both flags currently require `--readonly-project` and are incompatible with `--no-project`. Apple's `container` runtime does not support them yet.
 
 ## Philosophy: It's the AI's Box, Not Yours
 

--- a/README.md
+++ b/README.md
@@ -318,8 +318,8 @@ Both skills follow the standard Agent Skills layout so they can be validated and
 | `--runtime <name>` | Use `docker`, `podman`, or `container` (Apple) | |
 | `--image <name>` | Custom base image | |
 | `--mount <src:dst>` | Extra mount (repeatable) | |
-| `--exclude <glob>` | Hide matching project paths from the container (repeatable) | Apple `container`, without `--readonly-project` |
-| `--copy-as <src:dst>` | Mount a file at another project path inside the container (repeatable) | Apple `container`, without `--readonly-project` |
+| `--exclude <glob>` | Hide matching project paths from the container (repeatable) | Apple `container`, `--no-project`, without `--readonly-project` |
+| `--copy-as <src:dst>` | Mount a file at another project path inside the container (repeatable) | Apple `container`, `--no-project`, without `--readonly-project` |
 | `--env <KEY=val>` | Set environment variable (repeatable) | |
 | `--setup` | Run interactive setup before starting | |
 | `--ssh-agent` | Forward SSH agent socket | |
@@ -328,7 +328,8 @@ Both skills follow the standard Agent Skills layout so they can be validated and
 | `--pod <name>` | Join existing Podman pod (shares its network) | `--no-network`, `--network`, `--docker` |
 | `--no-yolo` | Disable auto-confirmations (mindful mode) | |
 | `--scratch` | Start with a fresh home/cache (nothing persists) | |
-| `--readonly-project` | Mount project read-only (outputs go to `/output`) | |
+| `--readonly-project` | Mount project read-only (outputs go to `/output`) | `--no-project` |
+| `--no-project` | Skip automatic project mount (caller provides `--mount` and `--runtime-arg=--workdir`) | `--readonly-project`, `--exclude`, `--copy-as` |
 | `--claude-config` | Copy host `~/.claude` config into container | |
 | `--codex-config` | Copy host `~/.codex` config into container | |
 | `--gemini-config` | Copy host `~/.gemini` config into container | |

--- a/cmd/yolobox/config.go
+++ b/cmd/yolobox/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	GitConfig             bool     `toml:"git_config"`
 	GhToken               bool     `toml:"gh_token"`
 	CopyAgentInstructions bool     `toml:"copy_agent_instructions"`
+	NoProject             bool     `toml:"no_project"`
 	Docker                bool     `toml:"docker"`
 	Clipboard             bool     `toml:"clipboard"`
 
@@ -191,6 +192,9 @@ func mergeConfig(dst *Config, src Config) {
 	if src.CopyAgentInstructions {
 		dst.CopyAgentInstructions = true
 	}
+	if src.NoProject {
+		dst.NoProject = true
+	}
 	if src.Docker {
 		dst.Docker = true
 	}
@@ -252,6 +256,7 @@ func printConfig(cfg Config) error {
 	fmt.Printf("%sgit_config:%s %t\n", colorBold, colorReset, cfg.GitConfig)
 	fmt.Printf("%sgh_token:%s %t\n", colorBold, colorReset, cfg.GhToken)
 	fmt.Printf("%scopy_agent_instructions:%s %t\n", colorBold, colorReset, cfg.CopyAgentInstructions)
+	fmt.Printf("%sno_project:%s %t\n", colorBold, colorReset, cfg.NoProject)
 	fmt.Printf("%sdocker:%s %t\n", colorBold, colorReset, cfg.Docker)
 	fmt.Printf("%sclipboard:%s %t\n", colorBold, colorReset, cfg.Clipboard)
 
@@ -352,6 +357,9 @@ func saveGlobalConfig(cfg Config) error {
 	}
 	if cfg.NoYolo {
 		lines = append(lines, "no_yolo = true")
+	}
+	if cfg.NoProject {
+		lines = append(lines, "no_project = true")
 	}
 	if cfg.Docker {
 		lines = append(lines, "docker = true")

--- a/cmd/yolobox/context_manifest.go
+++ b/cmd/yolobox/context_manifest.go
@@ -62,6 +62,7 @@ type contextConfigManifest struct {
 	CopyAs                []string                       `json:"copy_as"`
 	SSHAgent              bool                           `json:"ssh_agent"`
 	ReadonlyProject       bool                           `json:"readonly_project"`
+	NoProject             bool                           `json:"no_project"`
 	NoNetwork             bool                           `json:"no_network"`
 	Network               string                         `json:"network"`
 	Pod                   string                         `json:"pod"`
@@ -106,8 +107,15 @@ func buildContextManifest(cfg Config, projectDir string, command []string, inter
 		selectedRuntime = filepath.Base(runtimePath)
 	}
 
+	workingDir := projectDir
+	projectPath := projectDir
+	if cfg.NoProject {
+		workingDir = noProjectWorkingDir(cfg.RuntimeArgs)
+		projectPath = ""
+	}
+
 	paths := contextPaths{
-		Project: projectDir,
+		Project: projectPath,
 		Home:    "/home/yolo",
 	}
 	if cfg.ReadonlyProject {
@@ -138,7 +146,7 @@ func buildContextManifest(cfg Config, projectDir string, command []string, inter
 		Launch: contextLaunch{
 			Interactive:            interactive,
 			Command:                append([]string{}, command...),
-			WorkingDir:             projectDir,
+			WorkingDir:             workingDir,
 			ContextFile:            yoloboxContextFile,
 			AutoPassthroughEnvKeys: append([]string{}, autoPassthroughEnvKeys...),
 			GhTokenForwarded:       ghTokenForwarded,
@@ -154,6 +162,7 @@ func buildContextManifest(cfg Config, projectDir string, command []string, inter
 			CopyAs:                append([]string{}, cfg.CopyAs...),
 			SSHAgent:              cfg.SSHAgent,
 			ReadonlyProject:       cfg.ReadonlyProject,
+			NoProject:             cfg.NoProject,
 			NoNetwork:             cfg.NoNetwork,
 			Network:               cfg.Network,
 			Pod:                   cfg.Pod,
@@ -182,6 +191,29 @@ func buildContextManifest(cfg Config, projectDir string, command []string, inter
 			},
 		},
 	}
+}
+
+func noProjectWorkingDir(runtimeArgs []string) string {
+	workingDir := "/home/yolo"
+	for i := 0; i < len(runtimeArgs); i++ {
+		arg := runtimeArgs[i]
+		switch {
+		case arg == "--workdir" || arg == "-w":
+			if i+1 < len(runtimeArgs) && runtimeArgs[i+1] != "" {
+				workingDir = runtimeArgs[i+1]
+				i++
+			}
+		case strings.HasPrefix(arg, "--workdir="):
+			if value := strings.TrimPrefix(arg, "--workdir="); value != "" {
+				workingDir = value
+			}
+		case strings.HasPrefix(arg, "-w="):
+			if value := strings.TrimPrefix(arg, "-w="); value != "" {
+				workingDir = value
+			}
+		}
+	}
+	return workingDir
 }
 
 func envKeys(envSpecs []string) []string {

--- a/cmd/yolobox/main.go
+++ b/cmd/yolobox/main.go
@@ -275,6 +275,7 @@ func printUsage() {
 	fmt.Fprintln(os.Stderr, "  --git-config          Copy host git config to container")
 	fmt.Fprintln(os.Stderr, "  --gh-token            Forward GitHub token for gh and HTTPS git")
 	fmt.Fprintln(os.Stderr, "  --copy-agent-instructions  Copy global agent instructions and skills")
+	fmt.Fprintln(os.Stderr, "  --no-project          Skip automatic project mount (caller provides mounts)")
 	fmt.Fprintln(os.Stderr, "  --docker              Mount Docker socket and join shared network")
 	fmt.Fprintln(os.Stderr, "  --clipboard           Bridge text clipboard copy/paste to the host")
 	fmt.Fprintln(os.Stderr, "  --cpus <count>        Limit number of CPUs (supports fractions)")
@@ -338,6 +339,7 @@ func parseBaseFlags(name string, args []string, projectDir string) (Config, []st
 		gitConfig             bool
 		ghToken               bool
 		copyAgentInstructions bool
+		noProject             bool
 		docker                bool
 		clipboard             bool
 		setup                 bool
@@ -376,6 +378,7 @@ func parseBaseFlags(name string, args []string, projectDir string) (Config, []st
 	fs.BoolVar(&gitConfig, "git-config", false, "copy host git config to container")
 	fs.BoolVar(&ghToken, "gh-token", false, "forward GitHub CLI token (from gh auth token)")
 	fs.BoolVar(&copyAgentInstructions, "copy-agent-instructions", false, "copy agent instruction files and skills (CLAUDE.md, ~/.claude/skills, GEMINI.md, AGENTS.md, ~/.codex/skills)")
+	fs.BoolVar(&noProject, "no-project", false, "skip automatic project mount (caller provides mounts and workdir)")
 	fs.BoolVar(&docker, "docker", false, "mount Docker socket and join shared network")
 	fs.BoolVar(&clipboard, "clipboard", false, "bridge text clipboard copy/paste to the host")
 	fs.BoolVar(&setup, "setup", false, "run interactive setup before starting")
@@ -452,6 +455,9 @@ func parseBaseFlags(name string, args []string, projectDir string) (Config, []st
 	}
 	if copyAgentInstructions {
 		cfg.CopyAgentInstructions = true
+	}
+	if noProject {
+		cfg.NoProject = true
 	}
 	if docker {
 		cfg.Docker = true
@@ -536,6 +542,17 @@ func validateConfigConflicts(cfg Config) error {
 	}
 	if cfg.Clipboard && cfg.NoNetwork {
 		return fmt.Errorf("cannot use --clipboard with --no-network")
+	}
+	if cfg.NoProject {
+		if cfg.ReadonlyProject {
+			return fmt.Errorf("cannot use --no-project with --readonly-project")
+		}
+		if len(cfg.Exclude) > 0 {
+			return fmt.Errorf("cannot use --no-project with --exclude")
+		}
+		if len(cfg.CopyAs) > 0 {
+			return fmt.Errorf("cannot use --no-project with --copy-as")
+		}
 	}
 	if cfg.Pod != "" {
 		if cfg.Network != "" {
@@ -992,7 +1009,7 @@ func splitToolArgs(args []string) (yoloboxArgs, toolArgs []string) {
 		"ssh-agent": true, "readonly-project": true, "no-network": true,
 		"no-yolo": true, "scratch": true, "claude-config": true,
 		"codex-config": true, "gemini-config": true, "opencode-config": true, "git-config": true, "gh-token": true,
-		"copy-agent-instructions": true, "docker": true, "setup": true, "mount": true,
+		"copy-agent-instructions": true, "no-project": true, "docker": true, "setup": true, "mount": true,
 		"clipboard": true,
 		"exclude":   true, "copy-as": true,
 		"env": true, "h": true, "help": true,
@@ -1094,18 +1111,21 @@ func buildRunArgs(cfg Config, projectDir string, command []string, interactive b
 		args = append(args, "-i")
 	}
 
-	args = append(args, "-w", containerWorkingDir)
 	args = append(args, "-e", "YOLOBOX=1")
-	args = append(args, "-e", "YOLOBOX_PROJECT_PATH="+containerWorkingDir)
 
-	// Pass host UID/GID so the entrypoint can match the yolo user to the
-	// project directory owner (fixes virtiofs permission issues on Colima 0.10+).
-	// Skip for rootless Podman where --userns=keep-id handles UID mapping.
-	if !rootlessPodman {
-		if info, err := os.Stat(absProject); err == nil {
-			if stat, ok := info.Sys().(*syscall.Stat_t); ok {
-				args = append(args, "-e", fmt.Sprintf("YOLOBOX_HOST_UID=%d", stat.Uid))
-				args = append(args, "-e", fmt.Sprintf("YOLOBOX_HOST_GID=%d", stat.Gid))
+	if !cfg.NoProject {
+		args = append(args, "-w", containerWorkingDir)
+		args = append(args, "-e", "YOLOBOX_PROJECT_PATH="+containerWorkingDir)
+
+		// Pass host UID/GID so the entrypoint can match the yolo user to the
+		// project directory owner (fixes virtiofs permission issues on Colima 0.10+).
+		// Skip for rootless Podman where --userns=keep-id handles UID mapping.
+		if !rootlessPodman {
+			if info, err := os.Stat(absProject); err == nil {
+				if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+					args = append(args, "-e", fmt.Sprintf("YOLOBOX_HOST_UID=%d", stat.Uid))
+					args = append(args, "-e", fmt.Sprintf("YOLOBOX_HOST_GID=%d", stat.Gid))
+				}
 			}
 		}
 	}
@@ -1154,25 +1174,27 @@ func buildRunArgs(cfg Config, projectDir string, command []string, interactive b
 		args = append(args, "-e", env)
 	}
 
-	projectMountSource, overlayCleanupPaths, err := buildProjectFilterMounts(cfg, absProject)
-	if err != nil {
-		return nil, nil, err
-	}
-	cleanupPaths = append(cleanupPaths, overlayCleanupPaths...)
-
-	// Project mount at its real container path (for session continuity).
-	// A symlink /workspace -> real path is created by the entrypoint
-	projectMount := projectMountSource + ":" + projectMountTarget
-	if cfg.ReadonlyProject {
-		projectMount += ":ro"
-		// Create a writable output directory
-		if cfg.Scratch {
-			args = append(args, "-v", "/output") // anonymous volume, deleted with container
-		} else {
-			args = append(args, "-v", persistentVolumeMount("yolobox-output", "/output", rootlessPodman))
+	if !cfg.NoProject {
+		projectMountSource, overlayCleanupPaths, err := buildProjectFilterMounts(cfg, absProject)
+		if err != nil {
+			return nil, nil, err
 		}
+		cleanupPaths = append(cleanupPaths, overlayCleanupPaths...)
+
+		// Project mount at its real container path (for session continuity).
+		// A symlink /workspace -> real path is created by the entrypoint
+		projectMount := projectMountSource + ":" + projectMountTarget
+		if cfg.ReadonlyProject {
+			projectMount += ":ro"
+			// Create a writable output directory
+			if cfg.Scratch {
+				args = append(args, "-v", "/output") // anonymous volume, deleted with container
+			} else {
+				args = append(args, "-v", persistentVolumeMount("yolobox-output", "/output", rootlessPodman))
+			}
+		}
+		args = append(args, "-v", projectMount)
 	}
-	args = append(args, "-v", projectMount)
 
 	// Named volumes for persistence (skip if --scratch).
 	// Rootless Podman on SELinux-enabled hosts assigns per-container MCS

--- a/cmd/yolobox/main.go
+++ b/cmd/yolobox/main.go
@@ -848,6 +848,9 @@ func runSetup() (Config, error) {
 	if cfg.Clipboard {
 		selectedOptions = append(selectedOptions, "clipboard")
 	}
+	if cfg.NoProject {
+		selectedOptions = append(selectedOptions, "no_project")
+	}
 
 	// Print header with box
 	headerStyle := lipgloss.NewStyle().
@@ -875,6 +878,7 @@ func runSetup() (Config, error) {
 					huh.NewOption("SSH agent (for git over SSH)", "ssh_agent"),
 					huh.NewOption("Docker socket (run containers from sandbox)", "docker"),
 					huh.NewOption("Host clipboard (text copy/paste bridge; requires network)", "clipboard"),
+					huh.NewOption("No automatic project mount (advanced; provide mounts/workdir)", "no_project"),
 					huh.NewOption("No network (disables network, pod, Docker, and clipboard)", "no_network"),
 					huh.NewOption("No YOLO (disable auto-confirm in AI CLIs)", "no_yolo"),
 				).
@@ -954,6 +958,7 @@ func runSetup() (Config, error) {
 	cfg.SSHAgent = contains(selectedOptions, "ssh_agent")
 	cfg.Docker = contains(selectedOptions, "docker")
 	cfg.Clipboard = contains(selectedOptions, "clipboard")
+	cfg.NoProject = contains(selectedOptions, "no_project")
 	cfg.NoNetwork = contains(selectedOptions, "no_network")
 	cfg.NoYolo = contains(selectedOptions, "no_yolo")
 	cfg.Pod = strings.TrimSpace(podName)
@@ -1116,16 +1121,17 @@ func buildRunArgs(cfg Config, projectDir string, command []string, interactive b
 	if !cfg.NoProject {
 		args = append(args, "-w", containerWorkingDir)
 		args = append(args, "-e", "YOLOBOX_PROJECT_PATH="+containerWorkingDir)
+	}
 
-		// Pass host UID/GID so the entrypoint can match the yolo user to the
-		// project directory owner (fixes virtiofs permission issues on Colima 0.10+).
-		// Skip for rootless Podman where --userns=keep-id handles UID mapping.
-		if !rootlessPodman {
-			if info, err := os.Stat(absProject); err == nil {
-				if stat, ok := info.Sys().(*syscall.Stat_t); ok {
-					args = append(args, "-e", fmt.Sprintf("YOLOBOX_HOST_UID=%d", stat.Uid))
-					args = append(args, "-e", fmt.Sprintf("YOLOBOX_HOST_GID=%d", stat.Gid))
-				}
+	// Pass host UID/GID so the entrypoint can match the yolo user and repair
+	// persistent named-volume ownership. This is still needed with --no-project,
+	// because /home/yolo may have been remapped by an earlier run.
+	// Skip for rootless Podman where --userns=keep-id handles UID mapping.
+	if !rootlessPodman {
+		if info, err := os.Stat(absProject); err == nil {
+			if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+				args = append(args, "-e", fmt.Sprintf("YOLOBOX_HOST_UID=%d", stat.Uid))
+				args = append(args, "-e", fmt.Sprintf("YOLOBOX_HOST_GID=%d", stat.Gid))
 			}
 		}
 	}

--- a/cmd/yolobox/main_test.go
+++ b/cmd/yolobox/main_test.go
@@ -433,30 +433,31 @@ func TestBuildRunArgs(t *testing.T) {
 
 func TestBuildRunArgsNoProject(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	projectDir := t.TempDir()
 
 	cfg := Config{
 		Image:     "test-image",
 		NoProject: true,
 	}
 
-	args, _, err := buildRunArgs(cfg, "/test/project", []string{"bash"}, true)
+	args, _, err := buildRunArgs(cfg, projectDir, []string{"bash"}, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	argsStr := strings.Join(args, " ")
 
-	if strings.Contains(argsStr, "-w /test/project") {
+	if strings.Contains(argsStr, "-w "+projectDir) {
 		t.Error("--no-project should skip workdir")
 	}
 	if strings.Contains(argsStr, "YOLOBOX_PROJECT_PATH") {
 		t.Error("--no-project should skip YOLOBOX_PROJECT_PATH")
 	}
-	if strings.Contains(argsStr, "YOLOBOX_HOST_UID") {
-		t.Error("--no-project should skip host UID")
+	if !strings.Contains(argsStr, "YOLOBOX_HOST_UID") {
+		t.Error("--no-project should still pass host UID for persistent home volume ownership")
 	}
 	for i, arg := range args {
-		if arg == "-v" && i+1 < len(args) && strings.Contains(args[i+1], "/test/project") {
+		if arg == "-v" && i+1 < len(args) && strings.Contains(args[i+1], projectDir) {
 			t.Errorf("--no-project should skip project mount, found: %s", args[i+1])
 		}
 	}
@@ -464,6 +465,46 @@ func TestBuildRunArgsNoProject(t *testing.T) {
 	// Named volumes should still be present
 	if !strings.Contains(argsStr, "yolobox-home:/home/yolo") {
 		t.Error("expected yolobox-home volume even with --no-project")
+	}
+}
+
+func TestBuildRunArgsNoProjectContextManifest(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	projectDir := t.TempDir()
+
+	cfg := Config{
+		Image:       "test-image",
+		NoProject:   true,
+		RuntimeArgs: []string{"--workdir=/workspace"},
+	}
+
+	args, _, err := buildRunArgs(cfg, projectDir, []string{"bash"}, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	payload, ok := argEnvValue(args, yoloboxContextPayloadEnv)
+	if !ok {
+		t.Fatalf("expected %s env var, got %s", yoloboxContextPayloadEnv, strings.Join(args, " "))
+	}
+	data, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		t.Fatalf("failed to decode context manifest payload: %v", err)
+	}
+
+	var manifest contextManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("failed to decode context manifest: %v", err)
+	}
+
+	if !manifest.Config.NoProject {
+		t.Fatal("expected no_project in manifest config")
+	}
+	if manifest.Paths.Project != "" {
+		t.Fatalf("expected no project path when automatic project mount is disabled, got %q", manifest.Paths.Project)
+	}
+	if manifest.Launch.WorkingDir != "/workspace" {
+		t.Fatalf("expected workdir from runtime args, got %q", manifest.Launch.WorkingDir)
 	}
 }
 
@@ -641,6 +682,9 @@ func TestBuildRunArgsContextManifestContents(t *testing.T) {
 	if !manifest.Config.ReadonlyProject {
 		t.Fatal("expected readonly_project in manifest config")
 	}
+	if manifest.Config.NoProject {
+		t.Fatal("did not expect no_project in manifest config")
+	}
 	if !manifest.Config.NoYolo {
 		t.Fatal("expected no_yolo in manifest config")
 	}
@@ -701,12 +745,64 @@ func TestDescribeYoloboxContextReportsManifestProjectAccess(t *testing.T) {
 	output := string(out)
 	for _, want := range []string{
 		"Source: manifest",
+		"Automatic project mount: true",
 		"Readonly project mode: false",
 		"Project writable now: true",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected %q in output:\n%s", want, output)
 		}
+	}
+}
+
+func TestDescribeYoloboxContextReportsNoProjectManifest(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not available")
+	}
+
+	projectDir := t.TempDir()
+	contextDir := t.TempDir()
+	manifest := buildContextManifest(
+		Config{Image: "test-image", NoProject: true, RuntimeArgs: []string{"--workdir=/workspace"}},
+		projectDir,
+		[]string{"bash"},
+		false,
+		nil,
+		false,
+	)
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("failed to encode manifest: %v", err)
+	}
+	contextPath := filepath.Join(contextDir, "context.json")
+	if err := os.WriteFile(contextPath, data, 0644); err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+
+	cmd := exec.Command("bash", yoloboxSkillContextScriptPath(t))
+	cmd.Dir = projectDir
+	cmd.Env = append(os.Environ(), "YOLOBOX_CONTEXT_FILE="+contextPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("context script failed: %v\n%s", err, out)
+	}
+
+	output := string(out)
+	for _, want := range []string{
+		"Source: manifest",
+		"Automatic project mount: false",
+		"Project: (automatic mount disabled)",
+		"Workdir: /workspace",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected %q in output:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "Project writable now:") {
+		t.Fatalf("did not expect project writability check when automatic mount is disabled:\n%s", output)
 	}
 }
 
@@ -734,6 +830,7 @@ func TestDescribeYoloboxContextFallbackUsesProjectAccessBeforeOutputPath(t *test
 	output := string(out)
 	for _, want := range []string{
 		"Source: inferred (manifest unavailable)",
+		"Automatic project mount: unknown",
 		"Readonly project mode: false",
 		"Project writable now: true",
 	} {

--- a/cmd/yolobox/main_test.go
+++ b/cmd/yolobox/main_test.go
@@ -431,6 +431,78 @@ func TestBuildRunArgs(t *testing.T) {
 	}
 }
 
+func TestBuildRunArgsNoProject(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	cfg := Config{
+		Image:     "test-image",
+		NoProject: true,
+	}
+
+	args, _, err := buildRunArgs(cfg, "/test/project", []string{"bash"}, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	argsStr := strings.Join(args, " ")
+
+	if strings.Contains(argsStr, "-w /test/project") {
+		t.Error("--no-project should skip workdir")
+	}
+	if strings.Contains(argsStr, "YOLOBOX_PROJECT_PATH") {
+		t.Error("--no-project should skip YOLOBOX_PROJECT_PATH")
+	}
+	if strings.Contains(argsStr, "YOLOBOX_HOST_UID") {
+		t.Error("--no-project should skip host UID")
+	}
+	for i, arg := range args {
+		if arg == "-v" && i+1 < len(args) && strings.Contains(args[i+1], "/test/project") {
+			t.Errorf("--no-project should skip project mount, found: %s", args[i+1])
+		}
+	}
+
+	// Named volumes should still be present
+	if !strings.Contains(argsStr, "yolobox-home:/home/yolo") {
+		t.Error("expected yolobox-home volume even with --no-project")
+	}
+}
+
+func TestNoProjectConflicts(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{
+			name: "no-project with readonly-project",
+			cfg:  Config{NoProject: true, ReadonlyProject: true},
+			want: "cannot use --no-project with --readonly-project",
+		},
+		{
+			name: "no-project with exclude",
+			cfg:  Config{NoProject: true, Exclude: []string{"node_modules"}},
+			want: "cannot use --no-project with --exclude",
+		},
+		{
+			name: "no-project with copy-as",
+			cfg:  Config{NoProject: true, CopyAs: []string{"a.txt:b.txt"}},
+			want: "cannot use --no-project with --copy-as",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConfigConflicts(tt.cfg)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if err.Error() != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, err.Error())
+			}
+		})
+	}
+}
+
 func TestBuildRunArgsCopyAgentInstructionsIncludesAgentSkills(t *testing.T) {
 	projectDir := t.TempDir()
 	homeDir := t.TempDir()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,7 +66,20 @@ copy_as = [".env.sandbox:.env"]
 - `copy_as` destinations must stay inside the project and already exist as files
 - `copy_as` takes precedence if it targets the same path as `exclude`
 - both options currently require `readonly_project = true` or `--readonly-project`
+- both options are incompatible with `no_project = true` or `--no-project`
 - Apple's `container` runtime does not support this feature yet
+
+## Skipping the automatic project mount
+
+Set `no_project = true` only in advanced environments where yolobox's current working directory is not visible to the Docker or Podman daemon. In that mode, provide the mount and workdir explicitly:
+
+```toml
+no_project = true
+mounts = ["/host/path/to/project:/workspace"]
+runtime_args = ["--workdir=/workspace"]
+```
+
+`no_project = true` cannot be combined with `readonly_project`, `exclude`, or `copy_as`.
 
 ## Customization config
 

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -19,12 +19,13 @@ Flags go after the subcommand: `yolobox run --flag cmd` or `yolobox claude --fla
 | Flag | Description | Incompatible with |
 |------|-------------|-------------------|
 | `--mount <src:dst>` | Extra mount, repeatable | |
-| `--exclude <glob>` | Hide matching project paths from the container, repeatable | Apple `container`, without `--readonly-project` |
-| `--copy-as <src:dst>` | Mount a file at another project path inside the container, repeatable | Apple `container`, without `--readonly-project` |
+| `--exclude <glob>` | Hide matching project paths from the container, repeatable | Apple `container`, `--no-project`, without `--readonly-project` |
+| `--copy-as <src:dst>` | Mount a file at another project path inside the container, repeatable | Apple `container`, `--no-project`, without `--readonly-project` |
 | `--env <KEY=val>` | Extra environment variable, repeatable | |
 | `--setup` | Run interactive setup before starting | |
 | `--ssh-agent` | Forward SSH agent socket | |
-| `--readonly-project` | Mount the project read-only and write outputs to `/output` | |
+| `--readonly-project` | Mount the project read-only and write outputs to `/output` | `--no-project` |
+| `--no-project` | Skip the automatic project mount; caller provides `--mount` and `--runtime-arg=--workdir` | `--readonly-project`, `--exclude`, `--copy-as` |
 | `--claude-config` | Copy host `~/.claude` config into the container | |
 | `--codex-config` | Copy host `~/.codex` config into the container | |
 | `--gemini-config` | Copy host `~/.gemini` config into the container | |
@@ -116,10 +117,24 @@ yolobox claude --readonly-project --exclude ".env*" --copy-as ".env.sandbox:.env
 - `copy-as` destinations must stay inside the project and already exist as files
 - if both flags target the same path, `copy-as` wins
 - both flags currently require `--readonly-project`
+- both flags are incompatible with `--no-project`
 
 ::: warning
 `--exclude` and `--copy-as` are currently supported on Docker and Podman only. Apple's `container` runtime does not support them yet.
 :::
+
+## Skipping the automatic project mount
+
+Use `--no-project` when yolobox is running somewhere its current working directory is not visible to the Docker or Podman daemon, such as some Docker-in-Docker and remote-daemon setups.
+
+```bash
+yolobox run --no-project \
+  --mount /host/path/to/project:/workspace \
+  --runtime-arg=--workdir=/workspace \
+  bash
+```
+
+This disables the default project mount, default workdir, and `$YOLOBOX_PROJECT_PATH`. The caller is responsible for providing any mounts and workdir the command needs.
 
 ## Derived image customization
 

--- a/skills/yolobox/SKILL.md
+++ b/skills/yolobox/SKILL.md
@@ -15,10 +15,10 @@ Use this skill only for questions about the current yolobox environment from ins
 4. Call out the important operating assumptions for the current session:
    - you are inside a containerized sandbox, not on the host
    - `127.0.0.1` refers to this container, not the user's host
-   - the project is mounted in, but host files outside the exposed mounts are out of reach by default
+   - the project is mounted in unless `Automatic project mount` is false; host files outside the exposed mounts are out of reach by default
    - write access, output path, network access, Docker access, and forwarded env keys depend on the current manifest
    - if fork mode is active, this project is a copied folder mounted at the original source path and `COMPOSE_PROJECT_NAME` is namespaced for the fork
-5. Prefer concrete facts from `YOLOBOX_CONTEXT_FILE` over generic assumptions. Mention the current project path, workdir, runtime, readonly/output behavior, network mode, Docker socket access, SSH agent access, GitHub token availability for HTTPS Git auth, fork/Compose namespace if present, and any relevant env keys or customization settings. In the script output, `Readonly project mode` is the yolobox launch mode and `Project writable now` is the current filesystem write check.
+5. Prefer concrete facts from `YOLOBOX_CONTEXT_FILE` over generic assumptions. Mention whether the automatic project mount is active, the current project path when present, workdir, runtime, readonly/output behavior, network mode, Docker socket access, SSH agent access, GitHub token availability for HTTPS Git auth, fork/Compose namespace if present, and any relevant env keys or customization settings. In the script output, `Readonly project mode` is the yolobox launch mode and `Project writable now` is the current filesystem write check; when the automatic project mount is disabled, do not assume the original checkout path exists inside the container.
 6. If the script had to fall back to inference instead of the manifest, say so explicitly.
 7. If the user needs a specific field or the raw manifest, run `${CODEX_HOME:-$HOME/.codex}/skills/yolobox/scripts/describe-yolobox-context.sh --json` or query `$YOLOBOX_CONTEXT_FILE` directly with `jq`.
 8. Do not claim you are inside yolobox unless `YOLOBOX=1` or the manifest confirms it.

--- a/skills/yolobox/scripts/describe-yolobox-context.sh
+++ b/skills/yolobox/scripts/describe-yolobox-context.sh
@@ -82,12 +82,14 @@ if [[ -f "$context_file" ]] && command -v jq >/dev/null 2>&1; then
     jq -r \
         --arg project_writable "$project_writable" \
         '
+        (.config.no_project // false) as $no_project |
         [
             "Inside yolobox: yes",
             "Source: manifest",
-            "Project: " + .paths.project,
-            "Project writable now: " + $project_writable,
-            "Workdir: " + .launch.working_dir,
+            "Automatic project mount: " + (($no_project | not) | tostring),
+            (if $no_project then "Project: (automatic mount disabled)" else "Project: " + (.paths.project // "") end),
+            (if $no_project then empty else "Project writable now: " + $project_writable end),
+            "Workdir: " + (.launch.working_dir // ""),
             "Home: " + .paths.home,
             (if .paths.output != null and .paths.output != "" then "Output: " + .paths.output else empty end),
             (if .fork != null then "Fork: " + .fork.name else empty end),
@@ -153,6 +155,7 @@ fi
 
 printf 'Inside yolobox: %s\n' "$inside"
 printf 'Source: inferred (manifest unavailable)\n'
+printf 'Automatic project mount: unknown\n'
 printf 'Project: %s\n' "$project"
 printf 'Project writable now: %s\n' "$project_writable"
 printf 'Workdir: %s\n' "$workdir"


### PR DESCRIPTION
## Why

When running yolobox inside Docker-in-Docker environments (e.g., [dstack](https://dstack.ai/)), the container's CWD path differs from the Docker host path. For example:

- **Inside the dstack container:** CWD is `/workflow/my-repo`
- **On the Docker host:** the same directory is at `/root/.dstack/.../<hash>/workflow/my-repo`

The automatic project mount uses `CWD:CWD` as the volume source and target. Since `/workflow/my-repo` doesn't exist on the Docker host, `docker run` fails. The same issue applies to any nested container environment where inner filesystem paths don't map 1:1 to the Docker daemon's host paths.

## What changed

Added a `--no-project` flag that skips:
- The automatic `-v <project>:<project>` mount
- The `-w <project>` workdir setting
- The `YOLOBOX_PROJECT_PATH` environment variable
- The `YOLOBOX_HOST_UID` / `YOLOBOX_HOST_GID` detection (stats the project dir)

The caller provides their own mounts and workdir via `--mount` and `--runtime-arg=--workdir=...` with resolved host paths.

Conflicts with `--readonly-project`, `--exclude`, and `--copy-as` since those operate on the project mount.

Supported via CLI flag, `.yolobox.toml` config (`no_project = true`), and `yolobox setup`.

**Files changed:** `config.go` (field + merge + print + save), `main.go` (flag + guards + help + conflict validation + splitToolArgs), `main_test.go` (2 new tests), `README.md` (flags table).

## Testing

```bash
# Default behavior unchanged
$ ./yolobox run echo hello
hello

# --no-project skips project mount, caller provides mounts
$ mkdir -p /tmp/test-project && touch /tmp/test-project/{hello,world}.txt
$ ./yolobox run --no-project \
    --mount /tmp/test-project:/workspace \
    --runtime-arg=--workdir=/workspace \
    ls /workspace
hello.txt
world.txt

# Conflict detection
$ ./yolobox run --no-project --readonly-project echo hi
✗ cannot use --no-project with --readonly-project

$ ./yolobox run --no-project --exclude node_modules echo hi
✗ cannot use --no-project with --exclude

# Unit tests
$ make clean && make build && make test
PASS
ok  github.com/finbarr/yolobox/cmd/yolobox  0.138s
```

Tested on a dstack instance (Docker-in-Docker). On dstack, `/tmp` is inside the
outer container and not visible to the Docker daemon, so the mount test used a
home-directory path resolved to the Docker host path instead. Same behavior —
`--no-project` skips the automatic mount and the caller-provided `--mount` works.

**Environment:** Linux (Ubuntu 22.04), Docker 27.x, also tested on dstack (Docker-in-Docker)

## Checklist

- [x] I ran `make clean && make build && make test`
- [x] I tested the change end-to-end in a real container
- [x] I updated README.md (if adding/changing flags or config)