### PR TITLE
Make Apple container the preferred macOS runtime with full parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ there is no `v0.6.0` tag in this repository.
 
 ## Unreleased
 
+### Added
+
+- Made Apple `container` the preferred runtime on macOS: auto-detection now tries `container` before `docker` and `podman` (Linux order is unchanged).
+- Added an Apple container version gate: yolobox requires container >= 1.0 and prints upgrade instructions for older installs (`--runtime container` errors; auto-detection warns and falls back to Docker/Podman).
+- yolobox now starts the Apple container system service automatically when it is not running.
+- Enabled custom image builds (`--packages`, `--customize-file`, `--rebuild-image`) on Apple container via `container build`.
+- Enabled `--exclude` and `--copy-as` project filtering on Apple container.
+- Apple container runs now default to a 4 GB memory limit (its per-container VM default is too small for AI CLIs); explicit `--memory` or config still wins.
+
+### Changed
+
+- Apple container now uses direct file bind mounts (supported since container 1.0) instead of the staged `/host-files` directory workaround; the `YOLOBOX_HOST_FILES` entrypoint fallback was removed from the image. Older yolobox binaries need the previous image to copy host configs on Apple container.
+- `--scratch --readonly-project` on Apple container mounts `/output` as tmpfs because container does not auto-delete anonymous volumes.
+- `yolobox reset` and `yolobox uninstall` translate volume removal to `container volume delete` on Apple container.
+- `--gpus`, `--device`, and `--docker` now fail fast with clear errors on Apple container instead of passing unsupported flags through to `container run`.
+
 ## v0.18.4 - 2026-06-09
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -385,7 +385,7 @@ RUN printf '%s\n' \
     chmod +x /usr/local/bin/yolobox-uid-fix.sh
 
 # Create entrypoint script
-RUN mkdir -p /host-claude /host-codex /host-codex-sessions /host-gemini /host-opencode /host-pi /host-git /host-agent-instructions /host-files && \
+RUN mkdir -p /host-claude /host-codex /host-codex-sessions /host-gemini /host-opencode /host-pi /host-git /host-agent-instructions && \
     printf '%s\n' \
     '#!/bin/bash' \
     '' \
@@ -396,10 +396,6 @@ RUN mkdir -p /host-claude /host-codex /host-codex-sessions /host-gemini /host-op
     '    export YOLOBOX_SAVED_PATH="$PATH"' \
     '    exec sudo -E /usr/local/bin/yolobox-uid-fix.sh "$YOLOBOX_HOST_UID" "${YOLOBOX_HOST_GID:-$(id -g)}" -- "$0" "$@"' \
     'fi' \
-    '' \
-    '# Apple container workaround: files are in /host-files/ instead of separate mounts' \
-    '# Check YOLOBOX_HOST_FILES env var for the mount location' \
-    'HF="${YOLOBOX_HOST_FILES:-}"' \
     '' \
     'yolobox_timing_mark() {' \
     '    [ -n "${YOLOBOX_TIMING:-}" ] || return 0' \
@@ -490,7 +486,7 @@ RUN mkdir -p /host-claude /host-codex /host-codex-sessions /host-gemini /host-op
     'fi' \
     '' \
     '# Copy Claude config from host staging area if present' \
-    'if [ -d /host-claude/.claude ] || [ -f /host-claude/.claude.json ] || [ -f "$HF/claude/.claude.json" ]; then' \
+    'if [ -d /host-claude/.claude ] || [ -f /host-claude/.claude.json ]; then' \
     '    echo -e "\033[33m→ Copying host Claude config to container\033[0m" >&2' \
     'fi' \
     'if [ -d /host-claude/.claude ]; then' \
@@ -502,14 +498,9 @@ RUN mkdir -p /host-claude /host-codex /host-codex-sessions /host-gemini /host-op
     '    sudo rm -f /home/yolo/.claude.json' \
     '    sudo cp -a /host-claude/.claude.json /home/yolo/.claude.json' \
     '    sudo chown yolo:yolo /home/yolo/.claude.json' \
-    'elif [ -f "$HF/claude/.claude.json" ]; then' \
-    '    sudo rm -f /home/yolo/.claude.json' \
-    '    sudo cp -a "$HF/claude/.claude.json" /home/yolo/.claude.json' \
-    '    sudo chown yolo:yolo /home/yolo/.claude.json' \
     'fi' \
     '# Copy Claude credentials from macOS Keychain (extracted by yolobox)' \
     'CREDS_FILE="/host-claude/.credentials.json"' \
-    '[ ! -f "$CREDS_FILE" ] && [ -f "$HF/claude/.credentials.json" ] && CREDS_FILE="$HF/claude/.credentials.json"' \
     'if [ -f "$CREDS_FILE" ]; then' \
     '    mkdir -p /home/yolo/.claude' \
     '    sudo cp -a "$CREDS_FILE" /home/yolo/.claude/.credentials.json' \
@@ -581,11 +572,6 @@ RUN mkdir -p /host-claude /host-codex /host-codex-sessions /host-gemini /host-op
     '    sudo rm -f /home/yolo/.gitconfig' \
     '    sudo cp -a /host-git/.gitconfig /home/yolo/.gitconfig' \
     '    sudo chown yolo:yolo /home/yolo/.gitconfig' \
-    'elif [ -f "$HF/git/.gitconfig" ]; then' \
-    '    echo -e "\033[33m→ Copying host git config to container\033[0m" >&2' \
-    '    sudo rm -f /home/yolo/.gitconfig' \
-    '    sudo cp -a "$HF/git/.gitconfig" /home/yolo/.gitconfig' \
-    '    sudo chown yolo:yolo /home/yolo/.gitconfig' \
     'fi' \
     '' \
     '# Mark project directory as safe for git (ownership differs from container user)' \
@@ -597,7 +583,6 @@ RUN mkdir -p /host-claude /host-codex /host-codex-sessions /host-gemini /host-op
     'COPIED_AGENT_INSTRUCTIONS=0' \
     '# Claude: CLAUDE.md' \
     'CLAUDE_MD="/host-agent-instructions/claude/CLAUDE.md"' \
-    '[ ! -f "$CLAUDE_MD" ] && [ -f "$HF/agent-instructions/claude/CLAUDE.md" ] && CLAUDE_MD="$HF/agent-instructions/claude/CLAUDE.md"' \
     'if [ -f "$CLAUDE_MD" ]; then' \
     '    mkdir -p /home/yolo/.claude' \
     '    sudo cp -a "$CLAUDE_MD" /home/yolo/.claude/CLAUDE.md' \
@@ -606,7 +591,6 @@ RUN mkdir -p /host-claude /host-codex /host-codex-sessions /host-gemini /host-op
     'fi' \
     '# Claude: skills/ directory' \
     'CLAUDE_SKILLS_DIR="/host-agent-instructions/claude/skills"' \
-    '[ ! -d "$CLAUDE_SKILLS_DIR" ] && [ -d "$HF/agent-instructions/claude/skills" ] && CLAUDE_SKILLS_DIR="$HF/agent-instructions/claude/skills"' \
     'if [ -d "$CLAUDE_SKILLS_DIR" ]; then' \
     '    mkdir -p /home/yolo/.claude' \
     '    sudo rm -rf /home/yolo/.claude/skills' \
@@ -616,7 +600,6 @@ RUN mkdir -p /host-claude /host-codex /host-codex-sessions /host-gemini /host-op
     'fi' \
     '# Gemini: GEMINI.md' \
     'GEMINI_MD="/host-agent-instructions/gemini/GEMINI.md"' \
-    '[ ! -f "$GEMINI_MD" ] && [ -f "$HF/agent-instructions/gemini/GEMINI.md" ] && GEMINI_MD="$HF/agent-instructions/gemini/GEMINI.md"' \
     'if [ -f "$GEMINI_MD" ]; then' \
     '    mkdir -p /home/yolo/.gemini' \
     '    sudo cp -a "$GEMINI_MD" /home/yolo/.gemini/GEMINI.md' \
@@ -625,7 +608,6 @@ RUN mkdir -p /host-claude /host-codex /host-codex-sessions /host-gemini /host-op
     'fi' \
     '# Codex: AGENTS.md' \
     'CODEX_MD="/host-agent-instructions/codex/AGENTS.md"' \
-    '[ ! -f "$CODEX_MD" ] && [ -f "$HF/agent-instructions/codex/AGENTS.md" ] && CODEX_MD="$HF/agent-instructions/codex/AGENTS.md"' \
     'if [ -f "$CODEX_MD" ]; then' \
     '    mkdir -p /home/yolo/.codex' \
     '    sudo cp -a "$CODEX_MD" /home/yolo/.codex/AGENTS.md' \
@@ -634,7 +616,6 @@ RUN mkdir -p /host-claude /host-codex /host-codex-sessions /host-gemini /host-op
     'fi' \
     '# Codex: skills/ directory' \
     'CODEX_SKILLS_DIR="/host-agent-instructions/codex/skills"' \
-    '[ ! -d "$CODEX_SKILLS_DIR" ] && [ -d "$HF/agent-instructions/codex/skills" ] && CODEX_SKILLS_DIR="$HF/agent-instructions/codex/skills"' \
     'if [ -d "$CODEX_SKILLS_DIR" ]; then' \
     '    mkdir -p /home/yolo/.codex' \
     '    sudo rm -rf /home/yolo/.codex/skills' \
@@ -644,7 +625,6 @@ RUN mkdir -p /host-claude /host-codex /host-codex-sessions /host-gemini /host-op
     'fi' \
     '# Pi: AGENTS.md' \
     'PI_MD="/host-agent-instructions/pi/AGENTS.md"' \
-    '[ ! -f "$PI_MD" ] && [ -f "$HF/agent-instructions/pi/AGENTS.md" ] && PI_MD="$HF/agent-instructions/pi/AGENTS.md"' \
     'if [ -f "$PI_MD" ]; then' \
     '    mkdir -p /home/yolo/.pi/agent' \
     '    sudo cp -a "$PI_MD" /home/yolo/.pi/agent/AGENTS.md' \
@@ -653,7 +633,6 @@ RUN mkdir -p /host-claude /host-codex /host-codex-sessions /host-gemini /host-op
     'fi' \
     '# Pi: skills/ directory' \
     'PI_SKILLS_DIR="/host-agent-instructions/pi/skills"' \
-    '[ ! -d "$PI_SKILLS_DIR" ] && [ -d "$HF/agent-instructions/pi/skills" ] && PI_SKILLS_DIR="$HF/agent-instructions/pi/skills"' \
     'if [ -d "$PI_SKILLS_DIR" ]; then' \
     '    mkdir -p /home/yolo/.pi/agent' \
     '    sudo rm -rf /home/yolo/.pi/agent/skills' \

--- a/cmd/yolobox/apple_container.go
+++ b/cmd/yolobox/apple_container.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Apple's container tool gained the features yolobox depends on (file bind
+// mounts, image builds, named volume management) in 1.0.
+const minAppleContainerVersion = "1.0.0"
+
+var appleContainerVersionPattern = regexp.MustCompile(`\d+\.\d+\.\d+`)
+
+var (
+	appleContainerVersionMu   sync.Mutex
+	appleContainerVersionErrs = map[string]error{}
+)
+
+func appleContainerUpgradeError(version string) error {
+	return fmt.Errorf(`Apple container %s is too old; yolobox requires container >= %s.
+Upgrade with: brew upgrade container
+or install the latest signed pkg from https://github.com/apple/container/releases
+(container 1.0 requires macOS 26 on Apple silicon)`, version, minAppleContainerVersion)
+}
+
+// parseAppleContainerVersion extracts the first X.Y.Z version from
+// `container --version` output (e.g. "container CLI version 1.0.0 (build: release)").
+func parseAppleContainerVersion(output string) (string, error) {
+	match := appleContainerVersionPattern.FindString(output)
+	if match == "" {
+		return "", fmt.Errorf("no version found in Apple container output %q", strings.TrimSpace(output))
+	}
+	return match, nil
+}
+
+// appleContainerVersion probes the installed Apple container CLI version.
+// `--version` works on every release and does not need the system service;
+// `system version` is a fallback in case the plain output is unparseable.
+func appleContainerVersion(runtimePath string) (string, error) {
+	for _, args := range [][]string{{"--version"}, {"system", "version", "--format", "json"}} {
+		// A wedged container daemon can block CLI calls indefinitely; the
+		// version probe must never hang runtime auto-detection.
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		output, err := exec.CommandContext(ctx, runtimePath, args...).CombinedOutput()
+		cancel()
+		if err != nil {
+			continue
+		}
+		if version, err := parseAppleContainerVersion(string(output)); err == nil {
+			return version, nil
+		}
+	}
+	return "", fmt.Errorf("could not determine Apple container version")
+}
+
+// checkAppleContainerVersion errors when the Apple container CLI at
+// runtimePath is older than minAppleContainerVersion. Results are memoized
+// per path because resolveRuntime is called many times per invocation.
+func checkAppleContainerVersion(runtimePath string) error {
+	appleContainerVersionMu.Lock()
+	defer appleContainerVersionMu.Unlock()
+	if err, ok := appleContainerVersionErrs[runtimePath]; ok {
+		return err
+	}
+
+	err := func() error {
+		version, err := appleContainerVersion(runtimePath)
+		if err != nil {
+			return appleContainerUpgradeError("(unknown version)")
+		}
+		if compareSemver("v"+version, "v"+minAppleContainerVersion) < 0 {
+			return appleContainerUpgradeError(version)
+		}
+		return nil
+	}()
+	appleContainerVersionErrs[runtimePath] = err
+	return err
+}
+
+// ensureAppleContainerSystem starts the container system service when it is
+// not already running. The first start may prompt to download a Linux kernel,
+// so the command is wired to the terminal.
+func ensureAppleContainerSystem(runtimePath string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if exec.CommandContext(ctx, runtimePath, "system", "status").Run() == nil {
+		return nil
+	}
+
+	info("Starting Apple container system service...")
+	// --enable-kernel-install answers the first-run kernel download prompt,
+	// which would otherwise hang non-interactive runs.
+	cmd := exec.Command(runtimePath, "system", "start", "--enable-kernel-install")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("Apple container system service is not running and could not be started.\nRun `container system start` manually and retry")
+	}
+	return nil
+}
+
+// appleContainerPreflight gates container runs on a supported CLI version and
+// a running system service.
+func appleContainerPreflight(runtimePath string) error {
+	if err := checkAppleContainerVersion(runtimePath); err != nil {
+		return err
+	}
+	return ensureAppleContainerSystem(runtimePath)
+}
+
+// parseAppleImageDigest extracts an image identifier from
+// `container image inspect` output, which is JSON-only (no --format flag).
+// container 1.0 emits a JSON array whose entries carry the manifest digest
+// in an "id" field.
+func parseAppleImageDigest(output []byte) (string, error) {
+	var entries []map[string]any
+	if err := json.Unmarshal(output, &entries); err != nil || len(entries) == 0 {
+		return "", fmt.Errorf("unexpected Apple container image inspect output")
+	}
+	for _, key := range []string{"id", "digest"} {
+		if value, ok := entries[0][key].(string); ok && value != "" {
+			return value, nil
+		}
+	}
+	// The caller only needs a stable cache key, so fall back to hashing the
+	// inspect output when no identifier field is present.
+	sum := sha256.Sum256(output)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}

--- a/cmd/yolobox/apple_container_test.go
+++ b/cmd/yolobox/apple_container_test.go
@@ -1,0 +1,360 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func writeFakeRuntime(t *testing.T, dir, name, script string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
+		t.Fatalf("failed to write fake %s runtime: %v", name, err)
+	}
+	return path
+}
+
+func TestRuntimeAutoDetectOrder(t *testing.T) {
+	darwin := runtimeAutoDetectOrder("darwin")
+	if strings.Join(darwin, ",") != "container,docker,podman" {
+		t.Fatalf("unexpected darwin auto-detect order: %v", darwin)
+	}
+	linux := runtimeAutoDetectOrder("linux")
+	if strings.Join(linux, ",") != "docker,podman" {
+		t.Fatalf("unexpected linux auto-detect order: %v", linux)
+	}
+}
+
+func TestParseAppleContainerVersion(t *testing.T) {
+	tests := []struct {
+		output  string
+		want    string
+		wantErr bool
+	}{
+		{"container CLI version 1.0.0 (build: release, commit: abc1234)", "1.0.0", false},
+		{"container CLI version 0.4.1", "0.4.1", false},
+		{"container version 12.34.56\nextra line", "12.34.56", false},
+		{"no version here", "", true},
+		{"", "", true},
+	}
+	for _, tt := range tests {
+		got, err := parseAppleContainerVersion(tt.output)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("parseAppleContainerVersion(%q): expected error, got %q", tt.output, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseAppleContainerVersion(%q): unexpected error: %v", tt.output, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("parseAppleContainerVersion(%q) = %q, want %q", tt.output, got, tt.want)
+		}
+	}
+}
+
+func TestCheckAppleContainerVersion(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := writeFakeRuntime(t, dir, "container-old", "#!/bin/sh\necho 'container CLI version 0.9.0 (build: release, commit: abc)'\n")
+	newPath := writeFakeRuntime(t, dir, "container-new", "#!/bin/sh\necho 'container CLI version 1.2.0 (build: release, commit: def)'\n")
+	brokenPath := writeFakeRuntime(t, dir, "container-broken", "#!/bin/sh\nexit 1\n")
+
+	err := checkAppleContainerVersion(oldPath)
+	if err == nil {
+		t.Fatal("expected version error for container 0.9.0")
+	}
+	if !strings.Contains(err.Error(), "requires container >= 1.0.0") || !strings.Contains(err.Error(), "brew") {
+		t.Fatalf("unexpected version error: %v", err)
+	}
+
+	if err := checkAppleContainerVersion(newPath); err != nil {
+		t.Fatalf("unexpected error for container 1.2.0: %v", err)
+	}
+
+	if err := checkAppleContainerVersion(brokenPath); err == nil {
+		t.Fatal("expected error for broken container binary")
+	}
+}
+
+func TestCheckAppleContainerVersionMemoized(t *testing.T) {
+	dir := t.TempDir()
+	// The script appends to a counter file on each invocation.
+	marker := filepath.Join(dir, "calls")
+	path := writeFakeRuntime(t, dir, "container", "#!/bin/sh\necho x >> "+marker+"\necho 'container CLI version 1.0.0'\n")
+
+	for i := 0; i < 3; i++ {
+		if err := checkAppleContainerVersion(path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	data, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("expected probe to run once: %v", err)
+	}
+	if calls := strings.Count(string(data), "x"); calls != 1 {
+		t.Fatalf("expected exactly one probe invocation, got %d", calls)
+	}
+}
+
+func TestResolveRuntimeAutoDetectSkipsOldAppleContainer(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("auto-detect only prefers Apple container on darwin")
+	}
+	dir := t.TempDir()
+	writeFakeRuntime(t, dir, "container", "#!/bin/sh\necho 'container CLI version 0.9.0'\n")
+	dockerPath := writeFakeRuntime(t, dir, "docker", "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", dir)
+
+	path, err := resolveRuntime("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != dockerPath {
+		t.Fatalf("expected auto-detect to fall back to docker, got %s", path)
+	}
+}
+
+func TestResolveRuntimeAutoDetectPrefersAppleContainer(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("auto-detect only prefers Apple container on darwin")
+	}
+	dir := t.TempDir()
+	containerPath := writeFakeRuntime(t, dir, "container", "#!/bin/sh\necho 'container CLI version 1.0.0'\n")
+	writeFakeRuntime(t, dir, "docker", "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", dir)
+
+	path, err := resolveRuntime("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != containerPath {
+		t.Fatalf("expected auto-detect to prefer Apple container, got %s", path)
+	}
+}
+
+func TestVolumeRemoveArgs(t *testing.T) {
+	tests := []struct {
+		apple bool
+		force bool
+		want  string
+	}{
+		{true, false, "volume delete a b"},
+		{true, true, "volume delete a b"},
+		{false, false, "volume rm a b"},
+		{false, true, "volume rm -f a b"},
+	}
+	for _, tt := range tests {
+		got := strings.Join(volumeRemoveArgs(tt.apple, tt.force, "a", "b"), " ")
+		if got != tt.want {
+			t.Errorf("volumeRemoveArgs(%v, %v) = %q, want %q", tt.apple, tt.force, got, tt.want)
+		}
+	}
+}
+
+func TestParseAppleImageDigest(t *testing.T) {
+	// container 1.0 inspect format: array of {configuration, id, variants}.
+	digest, err := parseAppleImageDigest([]byte(`[{"configuration":{"name":"alpine"},"id":"e8cab8ec8514","variants":[]}]`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if digest != "e8cab8ec8514" {
+		t.Fatalf("unexpected digest: %q", digest)
+	}
+
+	digest, err = parseAppleImageDigest([]byte(`[{"name":"test","digest":"sha256:abc123"}]`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if digest != "sha256:abc123" {
+		t.Fatalf("unexpected digest: %q", digest)
+	}
+
+	// Missing digest falls back to a stable hash of the inspect output.
+	fallback1, err := parseAppleImageDigest([]byte(`[{"name":"test"}]`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fallback2, err := parseAppleImageDigest([]byte(`[{"name":"test"}]`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fallback1 != fallback2 || !strings.HasPrefix(fallback1, "sha256:") {
+		t.Fatalf("expected stable hashed fallback, got %q vs %q", fallback1, fallback2)
+	}
+
+	if _, err := parseAppleImageDigest([]byte("not json")); err == nil {
+		t.Fatal("expected error for non-JSON output")
+	}
+	if _, err := parseAppleImageDigest([]byte("[]")); err == nil {
+		t.Fatal("expected error for empty inspect output")
+	}
+}
+
+func setupFakeAppleContainerRuntime(t *testing.T) {
+	t.Helper()
+	runtimeDir := t.TempDir()
+	writeFakeRuntime(t, runtimeDir, "container", "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", runtimeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestBuildRunArgsAppleContainerDirectFileMounts(t *testing.T) {
+	setupFakeAppleContainerRuntime(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	gitConfig := filepath.Join(home, ".gitconfig")
+	if err := os.WriteFile(gitConfig, []byte("[user]\n\tname = Test\n"), 0644); err != nil {
+		t.Fatalf("failed to write .gitconfig: %v", err)
+	}
+
+	cfg := Config{
+		Runtime:   "container",
+		Image:     "test-image",
+		GitConfig: true,
+	}
+
+	args, _, err := buildRunArgs(cfg, t.TempDir(), []string{"bash"}, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	argsStr := strings.Join(args, " ")
+	if !strings.Contains(argsStr, gitConfig+":/host-git/.gitconfig:ro") {
+		t.Fatalf("expected direct .gitconfig file mount, got %s", argsStr)
+	}
+	if strings.Contains(argsStr, "/host-files") {
+		t.Fatalf("did not expect staged /host-files mount, got %s", argsStr)
+	}
+	if strings.Contains(argsStr, "YOLOBOX_HOST_FILES") {
+		t.Fatalf("did not expect YOLOBOX_HOST_FILES env var, got %s", argsStr)
+	}
+}
+
+func TestBuildRunArgsAppleContainerScratchOutputTmpfs(t *testing.T) {
+	setupFakeAppleContainerRuntime(t)
+
+	cfg := Config{
+		Runtime:         "container",
+		Image:           "test-image",
+		ReadonlyProject: true,
+		Scratch:         true,
+	}
+
+	args, _, err := buildRunArgs(cfg, t.TempDir(), []string{"bash"}, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	argsStr := strings.Join(args, " ")
+	if !strings.Contains(argsStr, "--tmpfs /output") {
+		t.Fatalf("expected tmpfs /output for Apple container scratch mode, got %s", argsStr)
+	}
+	if strings.Contains(argsStr, "-v /output") {
+		t.Fatalf("did not expect anonymous /output volume for Apple container, got %s", argsStr)
+	}
+}
+
+func TestBuildRunArgsAppleContainerDefaultMemory(t *testing.T) {
+	setupFakeAppleContainerRuntime(t)
+
+	cfg := Config{
+		Runtime: "container",
+		Image:   "test-image",
+	}
+	args, _, err := buildRunArgs(cfg, t.TempDir(), []string{"bash"}, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(strings.Join(args, " "), "--memory 4g") {
+		t.Fatalf("expected default --memory 4g for Apple container, got %s", strings.Join(args, " "))
+	}
+
+	cfg.Memory = "2g"
+	args, _, err = buildRunArgs(cfg, t.TempDir(), []string{"bash"}, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	argsStr := strings.Join(args, " ")
+	if !strings.Contains(argsStr, "--memory 2g") || strings.Contains(argsStr, "--memory 4g") {
+		t.Fatalf("expected explicit memory to win, got %s", argsStr)
+	}
+}
+
+func TestBuildRunArgsDockerNoDefaultMemory(t *testing.T) {
+	runtimeDir := t.TempDir()
+	writeFakeRuntime(t, runtimeDir, "docker", "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", runtimeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cfg := Config{
+		Runtime: "docker",
+		Image:   "test-image",
+	}
+	args, _, err := buildRunArgs(cfg, t.TempDir(), []string{"bash"}, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(strings.Join(args, " "), "--memory") {
+		t.Fatalf("did not expect default memory for docker/podman, got %s", strings.Join(args, " "))
+	}
+}
+
+func TestValidateRuntimeConstraintsAppleContainer(t *testing.T) {
+	setupFakeAppleContainerRuntime(t)
+
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr string
+	}{
+		{"gpus", Config{Runtime: "container", GPUs: "all"}, "--gpus"},
+		{"devices", Config{Runtime: "container", Devices: []string{"/dev/null"}}, "--device"},
+		{"docker socket", Config{Runtime: "container", Docker: true}, "--docker"},
+		{"clean", Config{Runtime: "container"}, ""},
+	}
+	for _, tt := range tests {
+		err := validateRuntimeConstraints(tt.cfg)
+		if tt.wantErr == "" {
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", tt.name, err)
+			}
+			continue
+		}
+		if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+			t.Errorf("%s: expected error mentioning %q, got %v", tt.name, tt.wantErr, err)
+		}
+	}
+}
+
+func TestGenerateCustomDockerfileWithoutCacheMounts(t *testing.T) {
+	dockerfile, err := generateCustomDockerfile("base", []string{"ripgrep"}, "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(dockerfile, "--mount=type=cache") {
+		t.Fatalf("did not expect BuildKit cache mounts:\n%s", dockerfile)
+	}
+	if strings.Contains(dockerfile, "# syntax=") {
+		t.Fatalf("did not expect BuildKit syntax directive:\n%s", dockerfile)
+	}
+	if !strings.Contains(dockerfile, "RUN apt-get update && apt-get install -y --no-install-recommends ripgrep") {
+		t.Fatalf("expected plain apt-get install:\n%s", dockerfile)
+	}
+}
+
+func TestHostBridgeHostNameAppleContainer(t *testing.T) {
+	setupFakeAppleContainerRuntime(t)
+	got := hostBridgeHostName("container")
+	// Apple container has no host.docker.internal-style hostname, so the
+	// bridge endpoint uses the host's LAN IP when one is available.
+	if want := firstNonLoopbackIPv4(); want != "" {
+		if got != want {
+			t.Fatalf("expected host LAN IP %q for Apple container, got %q", want, got)
+		}
+	} else if got != "host.containers.internal" {
+		t.Fatalf("unexpected fallback hostname for Apple container: %q", got)
+	}
+}

--- a/cmd/yolobox/clipboard_bridge.go
+++ b/cmd/yolobox/clipboard_bridge.go
@@ -147,7 +147,14 @@ func hostBridgeHostName(runtimeName string) string {
 		runtimeBase = filepath.Base(path)
 	}
 	switch runtimeBase {
-	case "podman", "container":
+	case "container":
+		// Apple container provides no host.docker.internal-style hostname;
+		// the host's LAN IP is reachable through the vmnet NAT.
+		if ip := firstNonLoopbackIPv4(); ip != "" {
+			return ip
+		}
+		return "host.containers.internal"
+	case "podman":
 		return "host.containers.internal"
 	default:
 		return "host.docker.internal"

--- a/cmd/yolobox/custom_image.go
+++ b/cmd/yolobox/custom_image.go
@@ -64,7 +64,7 @@ func loadCustomizeFragment(path string) (string, error) {
 	return strings.TrimSpace(string(data)), nil
 }
 
-func generateCustomDockerfile(baseImage string, packages []string, fragment string) (string, error) {
+func generateCustomDockerfile(baseImage string, packages []string, fragment string, useBuildKitCacheMounts bool) (string, error) {
 	normalized := normalizePackages(packages)
 	for _, pkg := range normalized {
 		if !isValidPackageName(pkg) {
@@ -73,16 +73,22 @@ func generateCustomDockerfile(baseImage string, packages []string, fragment stri
 	}
 
 	var builder strings.Builder
-	builder.WriteString("# syntax=docker/dockerfile:1\n")
+	if useBuildKitCacheMounts {
+		builder.WriteString("# syntax=docker/dockerfile:1\n")
+	}
 	builder.WriteString("FROM ")
 	builder.WriteString(baseImage)
 	builder.WriteString("\n")
 
 	if len(normalized) > 0 {
 		builder.WriteString("USER root\n")
-		builder.WriteString("RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \\\n")
-		builder.WriteString("    --mount=type=cache,target=/var/lib/apt,sharing=locked \\\n")
-		builder.WriteString("    apt-get update && apt-get install -y --no-install-recommends ")
+		if useBuildKitCacheMounts {
+			builder.WriteString("RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \\\n")
+			builder.WriteString("    --mount=type=cache,target=/var/lib/apt,sharing=locked \\\n")
+			builder.WriteString("    apt-get update && apt-get install -y --no-install-recommends ")
+		} else {
+			builder.WriteString("RUN apt-get update && apt-get install -y --no-install-recommends ")
+		}
 		builder.WriteString(strings.Join(normalized, " "))
 		builder.WriteString(" && rm -rf /var/lib/apt/lists/*\n")
 		builder.WriteString("USER yolo\n")
@@ -109,10 +115,9 @@ func customImageTag(baseImageID, dockerfile string, packages []string) string {
 }
 
 func inspectImageID(runtimePath, image string) (string, error) {
-	cmd := exec.Command(runtimePath, "image", "inspect", image, "--format", "{{.Id}}")
-	output, err := cmd.Output()
+	output, err := runImageInspect(runtimePath, image)
 	if err != nil {
-		pullCmd := exec.Command(runtimePath, "pull", image)
+		pullCmd := exec.Command(runtimePath, "image", "pull", image)
 		pullCmd.Stdin = os.Stdin
 		pullCmd.Stdout = os.Stdout
 		pullCmd.Stderr = os.Stderr
@@ -120,13 +125,24 @@ func inspectImageID(runtimePath, image string) (string, error) {
 			return "", fmt.Errorf("failed to inspect or pull base image %q: %w", image, err)
 		}
 
-		cmd = exec.Command(runtimePath, "image", "inspect", image, "--format", "{{.Id}}")
-		output, err = cmd.Output()
+		output, err = runImageInspect(runtimePath, image)
 		if err != nil {
 			return "", fmt.Errorf("failed to inspect base image %q: %w", image, err)
 		}
 	}
+	if isAppleContainerPath(runtimePath) {
+		return parseAppleImageDigest(output)
+	}
 	return strings.TrimSpace(string(output)), nil
+}
+
+// runImageInspect returns an image identifier in raw bytes. Apple's container
+// tool only emits JSON (no --format flag), so the caller parses its output.
+func runImageInspect(runtimePath, image string) ([]byte, error) {
+	if isAppleContainerPath(runtimePath) {
+		return exec.Command(runtimePath, "image", "inspect", image).Output()
+	}
+	return exec.Command(runtimePath, "image", "inspect", image, "--format", "{{.Id}}").Output()
 }
 
 func customImageExists(runtimePath, tag string) bool {
@@ -135,7 +151,9 @@ func customImageExists(runtimePath, tag string) bool {
 
 func buildCustomImage(runtimePath, tag, dockerfilePath, contextDir string) error {
 	cmd := exec.Command(runtimePath, "build", "-t", tag, "-f", dockerfilePath, contextDir)
-	cmd.Env = append(os.Environ(), "DOCKER_BUILDKIT=1")
+	if !isAppleContainerPath(runtimePath) {
+		cmd.Env = append(os.Environ(), "DOCKER_BUILDKIT=1")
+	}
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -146,9 +164,6 @@ func prepareCustomImage(cfg *Config, projectDir string) (string, error) {
 	runtimePath, err := resolveRuntime(cfg.Runtime)
 	if err != nil {
 		return "", err
-	}
-	if filepath.Base(runtimePath) == "container" {
-		return "", fmt.Errorf("custom images are not supported with Apple container runtime")
 	}
 
 	customizeFile, err := resolveCustomizeFile(cfg.Customize.Dockerfile, projectDir)
@@ -161,7 +176,7 @@ func prepareCustomImage(cfg *Config, projectDir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	dockerfile, err := generateCustomDockerfile(cfg.Image, cfg.Customize.Packages, fragment)
+	dockerfile, err := generateCustomDockerfile(cfg.Image, cfg.Customize.Packages, fragment, true)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/yolobox/fork.go
+++ b/cmd/yolobox/fork.go
@@ -216,7 +216,7 @@ func runComposeCleanup(info forkInfo) {
 		warn("Skipping Compose cleanup: %v", err)
 		return
 	}
-	if strings.HasSuffix(runtimePath, "/container") {
+	if isAppleContainerPath(runtimePath) {
 		return
 	}
 

--- a/cmd/yolobox/main.go
+++ b/cmd/yolobox/main.go
@@ -314,7 +314,7 @@ func printUsage() {
 	}
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintf(os.Stderr, "%sFLAGS:%s\n", colorBold, colorReset)
-	fmt.Fprintln(os.Stderr, "  --runtime <name>      Container runtime: docker, podman, or container")
+	fmt.Fprintln(os.Stderr, "  --runtime <name>      Container runtime: container (preferred on macOS), docker, or podman")
 	fmt.Fprintln(os.Stderr, "  --image <name>        Base image to use")
 	fmt.Fprintln(os.Stderr, "  --name <name>         Assign a runtime container name")
 	fmt.Fprintln(os.Stderr, "  --pod <name>          Join existing Podman pod (shares its network)")
@@ -674,7 +674,7 @@ func validateConfigConflicts(cfg Config) error {
 }
 
 func validateRuntimeConstraints(cfg Config) error {
-	if cfg.Pod == "" {
+	if cfg.Pod == "" && cfg.GPUs == "" && len(cfg.Devices) == 0 && !cfg.Docker {
 		return nil
 	}
 
@@ -682,8 +682,19 @@ func validateRuntimeConstraints(cfg Config) error {
 	if err != nil {
 		return err
 	}
-	if filepath.Base(runtimePath) != "podman" {
+	if cfg.Pod != "" && filepath.Base(runtimePath) != "podman" {
 		return fmt.Errorf("--pod requires the podman runtime (set --runtime podman)")
+	}
+	if isAppleContainerPath(runtimePath) {
+		if cfg.GPUs != "" {
+			return fmt.Errorf("--gpus is not supported by Apple container (use --runtime docker or podman)")
+		}
+		if len(cfg.Devices) > 0 {
+			return fmt.Errorf("--device is not supported by Apple container (use --runtime docker or podman)")
+		}
+		if cfg.Docker {
+			return fmt.Errorf("--docker (Docker socket forwarding) requires the docker or podman runtime")
+		}
 	}
 	return nil
 }
@@ -801,6 +812,17 @@ func runCommand(cfg Config, command []string, interactive bool) error {
 		return validateRuntimeConstraints(cfg)
 	}); err != nil {
 		return err
+	}
+	if isAppleContainer(cfg.Runtime) {
+		runtimePath, err := resolveRuntime(cfg.Runtime)
+		if err != nil {
+			return err
+		}
+		if err := traceTimed("host: apple container preflight", func() error {
+			return appleContainerPreflight(runtimePath)
+		}); err != nil {
+			return err
+		}
 	}
 	if hasCustomization(cfg) {
 		started = time.Now()
@@ -1312,11 +1334,7 @@ func buildRunArgs(cfg Config, projectDir string, command []string, interactive b
 	// that should be removed after the container exits
 	var cleanupPaths []string
 
-	// Check if we're using Apple container (doesn't support file mounts)
 	appleContainer := isAppleContainer(cfg.Runtime)
-	if appleContainer && (len(cfg.Exclude) > 0 || len(cfg.CopyAs) > 0) {
-		return nil, nil, fmt.Errorf("--exclude and --copy-as are not supported with Apple container runtime")
-	}
 
 	// Check if we're using rootless Podman (needs --userns=keep-id for bind mount permissions)
 	rootlessPodman := isRootlessPodman(cfg.Runtime)
@@ -1448,7 +1466,13 @@ func buildRunArgs(cfg Config, projectDir string, command []string, interactive b
 			projectMount += ":ro"
 			// Create a writable output directory
 			if cfg.Scratch {
-				args = append(args, "-v", "/output") // anonymous volume, deleted with container
+				if appleContainer {
+					// Apple container does not auto-delete anonymous volumes
+					// with --rm, so use a tmpfs for the same ephemeral semantics.
+					args = append(args, "--tmpfs", "/output")
+				} else {
+					args = append(args, "-v", "/output") // anonymous volume, deleted with container
+				}
 			} else {
 				args = append(args, "-v", persistentVolumeMount("yolobox-output", "/output", rootlessPodman))
 			}
@@ -1464,13 +1488,6 @@ func buildRunArgs(cfg Config, projectDir string, command []string, interactive b
 	if !cfg.Scratch {
 		args = append(args, "-v", persistentVolumeMount("yolobox-home", "/home/yolo", rootlessPodman))
 		args = append(args, "-v", persistentVolumeMount("yolobox-cache", "/var/cache", rootlessPodman))
-	}
-
-	// For Apple container, we need to collect files and mount via a temp directory
-	// (Apple container only supports directory mounts, not file mounts)
-	var appleContainerFiles map[string]string
-	if appleContainer {
-		appleContainerFiles = make(map[string]string)
 	}
 
 	// Mount Claude config from host to staging area (copied to /home/yolo by entrypoint)
@@ -1499,11 +1516,7 @@ func buildRunArgs(cfg Config, projectDir string, command []string, interactive b
 			// Preprocess to remove installMethod (host install method doesn't apply in container)
 			if processedPath := preprocessClaudeConfig(claudeConfigFile); processedPath != "" {
 				cleanupPaths = append(cleanupPaths, processedPath)
-				if appleContainer {
-					appleContainerFiles[processedPath] = "claude/.claude.json"
-				} else {
-					args = append(args, "-v", processedPath+":/host-claude/.claude.json:ro")
-				}
+				args = append(args, "-v", processedPath+":/host-claude/.claude.json:ro")
 			}
 		}
 		// On macOS, extract OAuth credentials from Keychain and mount as .credentials.json
@@ -1519,11 +1532,7 @@ func buildRunArgs(cfg Config, projectDir string, command []string, interactive b
 							if chmodErr := os.Chmod(f.Name(), 0600); chmodErr == nil {
 								credsPath := f.Name()
 								cleanupPaths = append(cleanupPaths, credsPath)
-								if appleContainer {
-									appleContainerFiles[credsPath] = "claude/.credentials.json"
-								} else {
-									args = append(args, "-v", credsPath+":/host-claude/.credentials.json:ro")
-								}
+								args = append(args, "-v", credsPath+":/host-claude/.credentials.json:ro")
 							} else {
 								_ = os.Remove(f.Name())
 							}
@@ -1642,11 +1651,7 @@ func buildRunArgs(cfg Config, projectDir string, command []string, interactive b
 		}
 		gitConfigFile := filepath.Join(home, ".gitconfig")
 		if _, err := os.Stat(gitConfigFile); err == nil {
-			if appleContainer {
-				appleContainerFiles[gitConfigFile] = "git/.gitconfig"
-			} else {
-				args = append(args, "-v", gitConfigFile+":/host-git/.gitconfig:ro")
-			}
+			args = append(args, "-v", gitConfigFile+":/host-git/.gitconfig:ro")
 		}
 		traceDuration("host: mount git config", started)
 	}
@@ -1662,11 +1667,7 @@ func buildRunArgs(cfg Config, projectDir string, command []string, interactive b
 		// Claude: ~/.claude/CLAUDE.md
 		claudeMd := filepath.Join(home, ".claude", "CLAUDE.md")
 		if _, err := os.Stat(claudeMd); err == nil {
-			if appleContainer {
-				appleContainerFiles[claudeMd] = "agent-instructions/claude/CLAUDE.md"
-			} else {
-				args = append(args, "-v", claudeMd+":/host-agent-instructions/claude/CLAUDE.md:ro")
-			}
+			args = append(args, "-v", claudeMd+":/host-agent-instructions/claude/CLAUDE.md:ro")
 		}
 		// Claude: ~/.claude/skills/ directory
 		claudeSkills := filepath.Join(home, ".claude", "skills")
@@ -1686,20 +1687,12 @@ func buildRunArgs(cfg Config, projectDir string, command []string, interactive b
 		// Gemini: ~/.gemini/GEMINI.md
 		geminiMd := filepath.Join(home, ".gemini", "GEMINI.md")
 		if _, err := os.Stat(geminiMd); err == nil {
-			if appleContainer {
-				appleContainerFiles[geminiMd] = "agent-instructions/gemini/GEMINI.md"
-			} else {
-				args = append(args, "-v", geminiMd+":/host-agent-instructions/gemini/GEMINI.md:ro")
-			}
+			args = append(args, "-v", geminiMd+":/host-agent-instructions/gemini/GEMINI.md:ro")
 		}
 		// Codex: ~/.codex/AGENTS.md
 		codexMd := filepath.Join(home, ".codex", "AGENTS.md")
 		if _, err := os.Stat(codexMd); err == nil {
-			if appleContainer {
-				appleContainerFiles[codexMd] = "agent-instructions/codex/AGENTS.md"
-			} else {
-				args = append(args, "-v", codexMd+":/host-agent-instructions/codex/AGENTS.md:ro")
-			}
+			args = append(args, "-v", codexMd+":/host-agent-instructions/codex/AGENTS.md:ro")
 		}
 		// Codex: ~/.codex/skills/ directory
 		codexSkills := filepath.Join(home, ".codex", "skills")
@@ -1719,11 +1712,7 @@ func buildRunArgs(cfg Config, projectDir string, command []string, interactive b
 		// Pi: ~/.pi/agent/AGENTS.md
 		piMd := filepath.Join(home, ".pi", "agent", "AGENTS.md")
 		if _, err := os.Stat(piMd); err == nil {
-			if appleContainer {
-				appleContainerFiles[piMd] = "agent-instructions/pi/AGENTS.md"
-			} else {
-				args = append(args, "-v", piMd+":/host-agent-instructions/pi/AGENTS.md:ro")
-			}
+			args = append(args, "-v", piMd+":/host-agent-instructions/pi/AGENTS.md:ro")
 		}
 		// Pi: ~/.pi/agent/skills/ directory
 		piSkills := filepath.Join(home, ".pi", "agent", "skills")
@@ -1740,7 +1729,7 @@ func buildRunArgs(cfg Config, projectDir string, command []string, interactive b
 			}
 			args = append(args, "-v", mountSrc+":/host-agent-instructions/pi/skills:ro")
 		}
-		// Copilot: ~/.copilot/agents/ directory (this is already a directory, works with Apple container)
+		// Copilot: ~/.copilot/agents/ directory
 		copilotAgents := filepath.Join(home, ".copilot", "agents")
 		if info, err := os.Stat(copilotAgents); err == nil && info.IsDir() {
 			mountSrc := copilotAgents
@@ -1758,18 +1747,6 @@ func buildRunArgs(cfg Config, projectDir string, command []string, interactive b
 		traceDuration("host: mount agent instructions", started)
 	}
 
-	// For Apple container: create temp dir with collected files and mount it
-	if appleContainer && len(appleContainerFiles) > 0 {
-		tmpDir, err := prepareFileMountDir(appleContainerFiles)
-		if err != nil {
-			return nil, nil, err
-		}
-		cleanupPaths = append(cleanupPaths, tmpDir)
-		// Mount the temp dir; entrypoint will need to handle the different paths
-		args = append(args, "-v", tmpDir+":/host-files:ro")
-		args = append(args, "-e", "YOLOBOX_HOST_FILES=/host-files")
-	}
-
 	// Extra mounts
 	for _, mount := range cfg.Mounts {
 		resolved, err := resolveMount(mount, absProject)
@@ -1781,7 +1758,13 @@ func buildRunArgs(cfg Config, projectDir string, command []string, interactive b
 
 	// Resource & security controls
 	args = appendRunFlag(args, "cpus", cfg.CPUs)
-	args = appendRunFlag(args, "memory", cfg.Memory)
+	memory := cfg.Memory
+	if memory == "" && appleContainer {
+		// Apple container allocates memory per container VM with a small
+		// default (~1G); AI CLIs need more headroom to avoid OOM kills.
+		memory = "4g"
+	}
+	args = appendRunFlag(args, "memory", memory)
 	args = appendRunFlag(args, "shm-size", cfg.ShmSize)
 	args = appendRunFlag(args, "gpus", cfg.GPUs)
 	for _, d := range cfg.Devices {
@@ -1926,18 +1909,41 @@ func parseCommaSeparatedValues(input string) []string {
 	return values
 }
 
+// runtimeAutoDetectOrder returns the runtimes tried during auto-detection.
+// Apple container is preferred on macOS; it does not exist elsewhere.
+func runtimeAutoDetectOrder(goos string) []string {
+	if goos == "darwin" {
+		return []string{"container", "docker", "podman"}
+	}
+	return []string{"docker", "podman"}
+}
+
+var appleContainerFallbackWarned bool
+
 func resolveRuntime(name string) (string, error) {
 	if name == "" {
-		if path, err := exec.LookPath("docker"); err == nil {
+		for _, candidate := range runtimeAutoDetectOrder(runtime.GOOS) {
+			path, err := exec.LookPath(candidate)
+			if err != nil {
+				continue
+			}
+			// Skip Apple container installs that are too old to support
+			// yolobox; explicit --runtime container still hard-errors later.
+			if candidate == "container" {
+				if verr := checkAppleContainerVersion(path); verr != nil {
+					if !appleContainerFallbackWarned {
+						appleContainerFallbackWarned = true
+						warn("Ignoring Apple container at %s: %v", path, verr)
+					}
+					continue
+				}
+			}
 			return path, nil
 		}
-		if path, err := exec.LookPath("podman"); err == nil {
-			return path, nil
+		if runtime.GOOS == "darwin" {
+			return "", fmt.Errorf("no container runtime found. Install Apple container, Docker, or Podman and try again")
 		}
-		if path, err := exec.LookPath("container"); err == nil {
-			return path, nil
-		}
-		return "", fmt.Errorf("no container runtime found. Install docker, podman, or Apple container and try again")
+		return "", fmt.Errorf("no container runtime found. Install docker or podman and try again")
 	}
 	if name == "colima" {
 		name = "docker"
@@ -2064,8 +2070,8 @@ func checkDockerMemory(runtime string) {
 		return
 	}
 
-	// Skip memory check for Apple container (uses native VM with dynamic memory)
-	if strings.HasSuffix(runtimePath, "/container") {
+	// Skip memory check for Apple container (memory is allocated per container VM)
+	if isAppleContainerPath(runtimePath) {
 		return
 	}
 

--- a/cmd/yolobox/main_test.go
+++ b/cmd/yolobox/main_test.go
@@ -46,7 +46,9 @@ exit 0
 	if err := os.WriteFile(dockerPath, []byte(script), 0755); err != nil {
 		t.Fatalf("failed to write fake docker runtime: %v", err)
 	}
-	t.Setenv("PATH", runtimeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	// Replace PATH entirely so runtime auto-detection cannot find a real
+	// container/docker/podman binary installed on the host.
+	t.Setenv("PATH", runtimeDir)
 	t.Setenv("YOLOBOX_FAKE_RUNTIME_ARGS", argsFile)
 	return argsFile
 }
@@ -1289,6 +1291,12 @@ func TestBuildRunArgsContextManifestAppleRuntime(t *testing.T) {
 	if !strings.Contains(argsStr, "YOLOBOX_CONTEXT_FILE=/run/yolobox/context.json") {
 		t.Fatalf("expected context env var for Apple container runtime, got %s", argsStr)
 	}
+	if strings.Contains(argsStr, "/host-files") {
+		t.Fatalf("did not expect staged /host-files mount for Apple container runtime, got %s", argsStr)
+	}
+	if strings.Contains(argsStr, "YOLOBOX_HOST_FILES") {
+		t.Fatalf("did not expect YOLOBOX_HOST_FILES env var for Apple container runtime, got %s", argsStr)
+	}
 }
 
 func TestBuildRunArgsNoYolo(t *testing.T) {
@@ -1946,8 +1954,11 @@ func TestBuildRunArgsProjectFilteringReadonlyProject(t *testing.T) {
 	}
 }
 
-func TestBuildRunArgsProjectFilteringAppleRuntimeUnsupported(t *testing.T) {
+func TestBuildRunArgsProjectFilteringAppleRuntimeSupported(t *testing.T) {
 	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, ".env"), []byte("SECRET=1\n"), 0644); err != nil {
+		t.Fatalf("failed to write .env: %v", err)
+	}
 	runtimeDir := t.TempDir()
 	containerPath := filepath.Join(runtimeDir, "container")
 	if err := os.WriteFile(containerPath, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
@@ -1956,17 +1967,29 @@ func TestBuildRunArgsProjectFilteringAppleRuntimeUnsupported(t *testing.T) {
 	t.Setenv("PATH", runtimeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	cfg := Config{
-		Runtime: "container",
-		Image:   "test-image",
-		Exclude: []string{".env*"},
+		Runtime:         "container",
+		Image:           "test-image",
+		ReadonlyProject: true,
+		Exclude:         []string{".env*"},
 	}
 
-	_, _, err := buildRunArgs(cfg, projectDir, []string{"bash"}, false)
-	if err == nil {
-		t.Fatal("expected Apple container runtime to reject file filtering")
-	}
-	if !strings.Contains(err.Error(), "not supported with Apple container runtime") {
+	args, cleanupPaths, err := buildRunArgs(cfg, projectDir, []string{"bash"}, false)
+	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+
+	argsStr := strings.Join(args, " ")
+	if len(cleanupPaths) == 0 {
+		t.Fatal("expected staged readonly project view")
+	}
+	viewRoot := cleanupPaths[0]
+	if !strings.Contains(argsStr, viewRoot+":"+projectDir+":ro") {
+		t.Fatalf("expected readonly staged project mount, got %s", argsStr)
+	}
+	if placeholder, err := os.ReadFile(filepath.Join(viewRoot, ".env")); err != nil {
+		t.Fatalf("expected excluded placeholder file in staged view: %v", err)
+	} else if len(placeholder) != 0 {
+		t.Fatalf("expected excluded placeholder to be empty, got %q", string(placeholder))
 	}
 }
 
@@ -2089,7 +2112,11 @@ func TestBuildRunArgsScratch(t *testing.T) {
 }
 
 func TestBuildRunArgsScratchWithReadonlyProject(t *testing.T) {
+	// Pin to docker: a host with Apple container installed would otherwise
+	// auto-detect it and use --tmpfs /output instead of an anonymous volume.
+	installFakeDockerRuntime(t)
 	cfg := Config{
+		Runtime:         "docker",
 		Image:           "test-image",
 		Scratch:         true,
 		ReadonlyProject: true,
@@ -2248,7 +2275,7 @@ func TestHasCustomization(t *testing.T) {
 }
 
 func TestGenerateCustomDockerfile(t *testing.T) {
-	dockerfile, err := generateCustomDockerfile("ghcr.io/finbarr/yolobox:latest", []string{"maven", "default-jdk", "maven"}, "USER root\nRUN echo hi\nUSER yolo\n")
+	dockerfile, err := generateCustomDockerfile("ghcr.io/finbarr/yolobox:latest", []string{"maven", "default-jdk", "maven"}, "USER root\nRUN echo hi\nUSER yolo\n", true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2265,7 +2292,7 @@ func TestGenerateCustomDockerfile(t *testing.T) {
 }
 
 func TestGenerateCustomDockerfileRejectsInvalidPackage(t *testing.T) {
-	_, err := generateCustomDockerfile("base", []string{"$(evil)"}, "")
+	_, err := generateCustomDockerfile("base", []string{"$(evil)"}, "", true)
 	if err == nil {
 		t.Fatal("expected invalid package to be rejected")
 	}

--- a/cmd/yolobox/maintenance.go
+++ b/cmd/yolobox/maintenance.go
@@ -40,8 +40,7 @@ func resetVolumes(args []string) error {
 
 	warn("Removing yolobox volumes...")
 	volumes := []string{"yolobox-home", "yolobox-cache"}
-	args = append([]string{"volume", "rm"}, volumes...)
-	if err := execCommand(runtimePath, args); err != nil {
+	if err := execCommand(runtimePath, volumeRemoveArgs(isAppleContainerPath(runtimePath), false, volumes...)); err != nil {
 		return err
 	}
 	success("Fresh start! All volumes removed.")
@@ -87,7 +86,7 @@ func uninstallYolobox(args []string) error {
 			if err == nil {
 				info("Removing Docker volumes...")
 				volumes := []string{"yolobox-home", "yolobox-cache", "yolobox-output"}
-				_ = execCommand(runtimePath, append([]string{"volume", "rm", "-f"}, volumes...))
+				_ = execCommand(runtimePath, volumeRemoveArgs(isAppleContainerPath(runtimePath), true, volumes...))
 			}
 		}
 	}
@@ -238,6 +237,11 @@ func upgradeYolobox(args []string) error {
 	runtimePath, err := resolveRuntime(cfg.Runtime)
 	if err != nil {
 		return err
+	}
+	if isAppleContainerPath(runtimePath) {
+		if err := appleContainerPreflight(runtimePath); err != nil {
+			return err
+		}
 	}
 	if err := execCommand(runtimePath, []string{"pull", cfg.Image}); err != nil {
 		return fmt.Errorf("failed to pull image: %w", err)

--- a/cmd/yolobox/runtime_support.go
+++ b/cmd/yolobox/runtime_support.go
@@ -13,13 +13,19 @@ import (
 
 var currentUID = os.Getuid
 
+// isAppleContainerPath checks if a resolved runtime binary path is Apple's
+// container tool.
+func isAppleContainerPath(path string) bool {
+	return filepath.Base(path) == "container"
+}
+
 // isAppleContainer checks if the resolved runtime is Apple's container tool.
 func isAppleContainer(runtime string) bool {
 	path, err := resolveRuntime(runtime)
 	if err != nil {
 		return false
 	}
-	return strings.HasSuffix(path, "/container")
+	return isAppleContainerPath(path)
 }
 
 // isRootlessPodman returns true when the resolved runtime is podman and the
@@ -32,6 +38,19 @@ func isRootlessPodman(runtime string) bool {
 		return false
 	}
 	return strings.HasSuffix(path, "/podman") && currentUID() != 0
+}
+
+// volumeRemoveArgs returns the runtime-appropriate volume removal command.
+// Apple's container tool uses `volume delete` and has no force flag.
+func volumeRemoveArgs(apple bool, force bool, volumes ...string) []string {
+	if apple {
+		return append([]string{"volume", "delete"}, volumes...)
+	}
+	args := []string{"volume", "rm"}
+	if force {
+		args = append(args, "-f")
+	}
+	return append(args, volumes...)
 }
 
 func persistentVolumeMount(name, target string, rootlessPodman bool) string {
@@ -117,31 +136,6 @@ func copyDirDereferenced(src, dst string) error {
 		}
 	}
 	return nil
-}
-
-// prepareFileMountDir creates a temp directory with copies of files for Apple container
-// (which only supports directory mounts, not file mounts). Returns the temp dir path.
-func prepareFileMountDir(files map[string]string) (string, error) {
-	tmpDir, err := os.MkdirTemp("", "yolobox-mounts-*")
-	if err != nil {
-		return "", fmt.Errorf("failed to create temp dir for file mounts: %w", err)
-	}
-
-	for srcPath, destName := range files {
-		data, err := os.ReadFile(srcPath)
-		if err != nil {
-			continue
-		}
-		destPath := filepath.Join(tmpDir, destName)
-		if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
-			continue
-		}
-		if err := os.WriteFile(destPath, data, 0644); err != nil {
-			continue
-		}
-	}
-
-	return tmpDir, nil
 }
 
 // findDockerSocket returns the Docker socket path to use as a volume mount source.
@@ -231,10 +225,16 @@ func ensureDockerNetwork(runtimeName string, networkName string) error {
 		return err
 	}
 
+	if exec.Command(runtimePath, "network", "inspect", networkName).Run() == nil {
+		return nil
+	}
+
 	cmd := exec.Command(runtimePath, "network", "create", networkName)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		if strings.Contains(string(output), "already exists") {
+		// Race guard: another yolobox instance may have created it between
+		// the inspect and the create.
+		if strings.Contains(strings.ToLower(string(output)), "exists") {
 			return nil
 		}
 		return fmt.Errorf("failed to create Docker network %q: %s", networkName, strings.TrimSpace(string(output)))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,7 +87,6 @@ copy_as = [".env.sandbox:.env"]
 - `copy_as` takes precedence if it targets the same path as `exclude`
 - both options currently require `readonly_project = true` or `--readonly-project`
 - both options are incompatible with `no_project = true` or `--no-project`
-- Apple's `container` runtime does not support this feature yet
 
 ## Skipping the automatic project mount
 

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -84,12 +84,11 @@ You still pay one rebuild after a base-image update, but you do not have to manu
 
 ## Runtime requirement
 
-Derived-image customization requires a runtime that can build images:
+Derived-image customization works on all supported runtimes:
 
+- Apple container (>= 1.0, builds with `container build`)
 - Docker
 - Podman
-
-Apple's `container` runtime can run yolobox, but it cannot build custom images.
 
 ## Fully custom images
 

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -11,17 +11,17 @@ Flags go after the subcommand: `yolobox run --flag cmd` or `yolobox claude --fla
 | `--runtime <name>` | Use `docker`, `podman`, or `container` | |
 | `--image <name>` | Override the base image | |
 | `--name <name>` | Assign a runtime container name | |
-| `--packages <list>` | Comma-separated apt packages for a derived custom image | Apple `container` |
-| `--customize-file <path>` | Dockerfile fragment for a derived custom image | Apple `container` |
-| `--rebuild-image` | Force rebuild of the derived custom image | Apple `container` |
+| `--packages <list>` | Comma-separated apt packages for a derived custom image | |
+| `--customize-file <path>` | Dockerfile fragment for a derived custom image | |
+| `--rebuild-image` | Force rebuild of the derived custom image | |
 
 ## Filesystem, config, and identity
 
 | Flag | Description | Incompatible with |
 |------|-------------|-------------------|
 | `--mount <src:dst>` | Extra mount, repeatable | |
-| `--exclude <glob>` | Hide matching project paths from the container, repeatable | Apple `container`, `--no-project`, without `--readonly-project` |
-| `--copy-as <src:dst>` | Mount a file at another project path inside the container, repeatable | Apple `container`, `--no-project`, without `--readonly-project` |
+| `--exclude <glob>` | Hide matching project paths from the container, repeatable | `--no-project`, without `--readonly-project` |
+| `--copy-as <src:dst>` | Mount a file at another project path inside the container, repeatable | `--no-project`, without `--readonly-project` |
 | `--env <KEY=val>` | Extra environment variable, repeatable | |
 | `--no-env-passthrough` | Disable automatic host environment passthrough | |
 | `--setup` | Run interactive setup before starting | |
@@ -49,7 +49,7 @@ Flags go after the subcommand: `yolobox run --flag cmd` or `yolobox claude --fla
 | `--pod <name>` | Join an existing Podman pod | `--no-network`, `--network`, `--docker` |
 | `--no-yolo` | Disable auto-confirmations | |
 | `--scratch` | Start with a fresh home and cache | |
-| `--docker` | Mount the Docker socket and join the shared `yolobox-net` network | `--no-network`, `--pod` |
+| `--docker` | Mount the Docker socket and join the shared `yolobox-net` network | `--no-network`, `--pod`, Apple `container` |
 
 ## Resources and low-level runtime control
 
@@ -58,8 +58,8 @@ Flags go after the subcommand: `yolobox run --flag cmd` or `yolobox claude --fla
 | `--cpus <num>` | Limit CPUs, including fractional values like `3.5` | |
 | `--memory <limit>` | Hard memory limit like `8g` or `1024m` | |
 | `--shm-size <size>` | Size of `/dev/shm` | |
-| `--gpus <spec>` | Pass GPUs, for example `all` or `device=0` | |
-| `--device <src:dest>` | Add host devices, repeatable | |
+| `--gpus <spec>` | Pass GPUs, for example `all` or `device=0` | Apple `container` |
+| `--device <src:dest>` | Add host devices, repeatable | Apple `container` |
 | `--cap-add <cap>` | Add Linux capabilities, repeatable | |
 | `--cap-drop <cap>` | Drop Linux capabilities, repeatable | |
 | `--runtime-arg <flag>` | Pass raw runtime flags directly to Docker or Podman | |
@@ -146,9 +146,6 @@ yolobox claude --readonly-project --exclude ".env*" --copy-as ".env.sandbox:.env
 - both flags currently require `--readonly-project`
 - both flags are incompatible with `--no-project`
 
-::: warning
-`--exclude` and `--copy-as` are currently supported on Docker and Podman only. Apple's `container` runtime does not support them yet.
-:::
 
 ## Skipping the automatic project mount
 
@@ -188,4 +185,4 @@ yolobox run \
   claude
 ```
 
-Docker and Podman accept these passthrough flags unchanged. Apple's `container` runtime ignores options it does not understand.
+Docker and Podman accept these passthrough flags unchanged. Apple's `container` runtime rejects options it does not understand, so only pass flags from its own `container run --help`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,19 +61,31 @@ You can also set a default harness in config, such as `default_harness = "codex"
 
 ## Runtime support
 
-yolobox auto-detects the first supported runtime it can use.
+yolobox auto-detects the first supported runtime it can use. On macOS the
+order is Apple container → Docker → Podman; on Linux it is Docker → Podman.
 
 | Platform | Supported runtimes |
 |---|---|
-| macOS | Docker Desktop, OrbStack, Colima, Apple container (macOS Tahoe+) |
+| macOS | Apple container (macOS 26+, Apple silicon, container >= 1.0), Docker Desktop, OrbStack, Colima |
 | Linux | Docker, Podman |
+
+Apple's [container](https://github.com/apple/container) runs each sandbox in
+its own lightweight VM with no Docker daemon required:
+
+```bash
+brew install container
+container system start
+```
+
+yolobox requires container >= 1.0 and skips older installs during
+auto-detection (it starts the system service automatically when needed).
 
 Force a runtime explicitly:
 
 ```bash
+yolobox claude --runtime container
 yolobox claude --runtime docker
 yolobox claude --runtime podman
-yolobox claude --runtime container
 ```
 
 ## Next pages
@@ -90,4 +102,7 @@ Claude Code needs at least 4 GB of RAM allocated to Docker. Colima defaults to 2
 ```bash
 colima stop && colima start --memory 8
 ```
+
+Apple container allocates memory per container VM, so yolobox defaults it to
+4 GB there. Raise it with `--memory 8g` or `memory = "8g"` in config if needed.
 :::


### PR DESCRIPTION
## Why

Apple's [container](https://github.com/apple/container) reached 1.0 and now supports file bind mounts, image builds, named volumes, and SSH agent forwarding — so it no longer needs to be a feature-limited last-resort runtime on macOS. This makes it the preferred macOS runtime (no Docker daemon required) and removes the workarounds that existed for its 0.x limitations.

## What changed

Auto-detection on macOS now tries `container → docker → podman` and requires container >= 1.0 (warn-and-fallback during detection, hard error when explicit, plus auto-starting the system service). File configs are now passed as direct `-v` bind mounts instead of being staged into a temp `/host-files` dir (the `YOLOBOX_HOST_FILES` entrypoint workaround is deleted), and `--exclude`/`--copy-as` plus custom image builds (`--packages`/`--customize-file`/`--rebuild-image`) are enabled on Apple container. Runtime differences are translated (`volume delete`, `--tmpfs /output` for scratch, JSON `image inspect` parsing, a 4 GB default memory), and `--gpus`/`--device`/`--docker` now fail fast with clear errors. Docs, CHANGELOG, and tests are updated; new `cmd/yolobox/apple_container.go` holds the version gate, preflight, and digest parsing.

## Testing

Verified end-to-end on macOS 26 (Apple silicon) against the real `container` 1.0.0 CLI with the yolobox image loaded:

```
$ go vet ./... && go test ./...
ok  github.com/finbarr/yolobox/cmd/yolobox

$ yolobox run grep MemTotal /proc/meminfo        # auto-detected Apple container
MemTotal:        4155792 kB                       # 4g default applied
$ yolobox run --git-config sh -c 'head -1 /home/yolo/.gitconfig'
[user]
$ yolobox run --readonly-project --exclude .env.sandbox --copy-as .env.sandbox:.env cat .env
SECRET=sandbox
$ yolobox run --packages ripgrep rg --version     # custom image built via `container build`
ripgrep 14.x
$ yolobox run --readonly-project --scratch sh -c 'mount | grep /output'
tmpfs on /output type tmpfs (rw,relatime)
$ yolobox run --gpus all echo hi
✗ --gpus is not supported by Apple container (use --runtime docker or podman)
$ yolobox reset --force                            # uses `container volume delete`
✓ Fresh start! All volumes removed.
```

**Environment:** macOS 26 (Darwin 25), Apple silicon; Apple `container` 1.0.0. Also unit-tested against Docker 28.5 (OrbStack).

## Checklist

- [x] I ran `make clean && make build && make test`
- [x] I tested the change end-to-end in a real container
- [x] I updated docs (getting-started, flags, configuration, customizing) and CHANGELOG

> Note: the clipboard/open bridge now uses the host LAN IP for Apple container (it exposes no `host.docker.internal`-style name); the host-inbound round-trip could not be exercised from the sandboxed test shell and is worth one manual check.